### PR TITLE
更新Docker部署ES版本

### DIFF
--- a/docker/run-all/docker-compose.yml
+++ b/docker/run-all/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       - TZ=Asia/Shanghai
   elasticsearch:
-    image: elasticsearch:6.8.11
+    image: elasticsearch:7.6.2
     container_name: jetlinks-ce-elasticsearch
     environment:
       ES_JAVA_OPTS: -Djava.net.preferIPv4Stack=true -Xms1g -Xmx1g
@@ -26,7 +26,7 @@ services:
   #      - "9200:9200"
   #      - "9300:9300"
   kibana:
-    image: kibana:6.8.11
+    image: kibana:7.6.2
     container_name: jetlinks-ce-kibana
     environment:
       ELASTICSEARCH_URL: http://elasticsearch:9200


### PR DESCRIPTION
由于Spring Boot 使用2.3.X，依照官网ES参考文件，需要使用ES 7.6.2 否则会报错
https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/#preface.requirements