### PR TITLE
fix(设备管理): 修复新增协议事件未触发导致协议不生效问题

### DIFF
--- a/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/service/DeviceProductHandler.java
+++ b/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/service/DeviceProductHandler.java
@@ -2,6 +2,7 @@ package org.jetlinks.community.device.service;
 
 import lombok.AllArgsConstructor;
 import org.hswebframework.web.bean.FastBeanCopier;
+import org.hswebframework.web.crud.events.EntityCreatedEvent;
 import org.hswebframework.web.crud.events.EntityModifyEvent;
 import org.hswebframework.web.crud.events.EntitySavedEvent;
 import org.jetlinks.core.device.DeviceRegistry;
@@ -34,6 +35,14 @@ public class DeviceProductHandler {
             applyProductConfig(event.getEntity())
         );
     }
+
+    @EventListener
+    public void handleProductSaveEvent(EntityCreatedEvent<DeviceProductEntity> event) {
+        event.async(
+            applyProductConfig(event.getEntity())
+        );
+    }
+
 
     @EventListener
     public void handleProductSaveEvent(EntityModifyEvent<DeviceProductEntity> event) {


### PR DESCRIPTION
前端调用新增协议的接口对应的 service 进行的是 insert 操作，触发的事件应该是 org.hswebframework.web.crud.events.EntityCreatedEvent