### PR TITLE
add(规则引擎-场景联动): 场景联动增加"读取属性后回复"触发场景联动的拓展

### DIFF
--- a/jetlinks-manager/rule-engine-manager/src/main/java/org/jetlinks/community/rule/engine/scene/DeviceOperation.java
+++ b/jetlinks-manager/rule-engine-manager/src/main/java/org/jetlinks/community/rule/engine/scene/DeviceOperation.java
@@ -124,6 +124,7 @@ public class DeviceOperation {
         //属性相关
         if (operator == Operator.readProperty
             || operator == Operator.reportProperty
+            || operator == Operator.readPropertyReply
             || operator == Operator.writeProperty) {
             terms.addAll(
                 this.createTerm(
@@ -252,6 +253,7 @@ public class DeviceOperation {
             case online:
             case offline:
             case reportProperty:
+            case readPropertyReply:
                 return;
             case reportEvent:
                 Assert.hasText(eventId, "error.scene_rule_trigger_device_operation_event_id_cannot_be_null");
@@ -281,6 +283,8 @@ public class DeviceOperation {
         reportProperty,
         //读取属性
         readProperty,
+        //读取属性回复
+        readPropertyReply,
         //修改属性
         writeProperty,
         //调用功能

--- a/jetlinks-manager/rule-engine-manager/src/main/java/org/jetlinks/community/rule/engine/scene/internal/triggers/DeviceTrigger.java
+++ b/jetlinks-manager/rule-engine-manager/src/main/java/org/jetlinks/community/rule/engine/scene/internal/triggers/DeviceTrigger.java
@@ -107,6 +107,7 @@ public class DeviceTrigger extends DeviceSelectorSpec implements SceneTriggerPro
             case writeProperty:
                 selectColumns.add("this.success \"success\"");
             case reportProperty:
+            case readPropertyReply:
                 selectColumns.add("this.properties \"properties\"");
                 break;
             case reportEvent:
@@ -184,6 +185,9 @@ public class DeviceTrigger extends DeviceSelectorSpec implements SceneTriggerPro
         switch (operation.getOperator()) {
             case reportProperty:
                 topic = "/device/" + productId + "/%s/message/property/report";
+                break;
+            case readPropertyReply:
+                topic = "/device/" + productId + "/%s/message/property/read/reply";
                 break;
             case reportEvent:
                 topic = "/device/" + productId + "/%s/message/event/" + operation.getEventId();
@@ -429,6 +433,7 @@ public class DeviceTrigger extends DeviceSelectorSpec implements SceneTriggerPro
             case offline:
             case reportEvent:
             case reportProperty:
+            case readPropertyReply:
                 return;
         }
 


### PR DESCRIPTION
需要结合前端一起拓展，前端的实现基于属性上报，把属性上报reportProperty修改为readPropertyReply即可。
属性回复结合多分支条件，可以实现批量轮询与判断告警在页面上配置的解耦。
测试了一段时间，触发是正常的。