### PR TITLE
refactor(告警模块)：告警级别信息增加拓展

### DIFF
--- a/jetlinks-manager/rule-engine-manager/src/main/java/org/jetlinks/community/rule/engine/alarm/AlarmLevelInfo.java
+++ b/jetlinks-manager/rule-engine-manager/src/main/java/org/jetlinks/community/rule/engine/alarm/AlarmLevelInfo.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Map;
+
 /**
  * @author bestfeng
  */
@@ -16,4 +18,7 @@ public class AlarmLevelInfo {
 
     @Schema(description = "名称")
     private String title;
+
+    @Schema(description = "拓展")
+    private Map<String, Object> expands;
 }


### PR DESCRIPTION
用户可能需要对告警级别所含信息进行拓展，比如我司每个告警级别对应一个不同的播报音。播报音在前端配置，由浏览器读出。