### PR TITLE
fix: 修复邮件通知类型中username未赋值导致的setFrom逻辑错误

### DIFF
--- a/jetlinks-components/notify-component/notify-email/src/main/java/org/jetlinks/community/notify/email/embedded/DefaultEmailNotifier.java
+++ b/jetlinks-components/notify-component/notify-email/src/main/java/org/jetlinks/community/notify/email/embedded/DefaultEmailNotifier.java
@@ -125,6 +125,7 @@ public class DefaultEmailNotifier extends AbstractNotifier<EmailTemplate> {
         mailSender.setJavaMailProperties(properties.createJavaMailProperties());
         this.notifierId = id;
         this.sender = properties.getSender();
+        this.username = properties.getUsername();
         this.javaMailSender = mailSender;
         this.fileManager = fileManager;
         this.webClient = builder.build();


### PR DESCRIPTION
可考虑同步修改前端邮件配置页面中对发件人的填写格式限定，用于发送邮件时“发件人“信息的显示，应可配置为个人、企业、平台等名称，本地测试正常