### PR TITLE
feat(timescaledb): 支持配置schema并优化时间分组查询

### DIFF
--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/TimescaleDBOperations.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/TimescaleDBOperations.java
@@ -21,6 +21,8 @@ public interface TimescaleDBOperations {
 
     DatabaseOperator database();
 
+    String schema();
+
     TimescaleDBDataWriter writer();
 
 }

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/TimescaleDBOperations.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/TimescaleDBOperations.java
@@ -21,7 +21,7 @@ public interface TimescaleDBOperations {
 
     DatabaseOperator database();
 
-    String schema();
+    String functionSchema();
 
     TimescaleDBDataWriter writer();
 

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/TimescaleDBProperties.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/TimescaleDBProperties.java
@@ -36,8 +36,8 @@ public class TimescaleDBProperties {
     //当sharedSpring未false时,使用此连接配置.
     private R2dbcProperties r2dbc = new R2dbcProperties();
 
-    //数据库的schema
-    private String schema = "public";
+    //数据函数的schema
+    private String functionSchema = "public";
 
     /**
      * 写入缓冲区配置

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/TimescaleDBUtils.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/TimescaleDBUtils.java
@@ -20,17 +20,16 @@ import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
 import org.hswebframework.ezorm.rdb.operator.dml.query.NativeSelectColumn;
 import org.hswebframework.ezorm.rdb.operator.dml.query.SelectColumn;
 import org.hswebframework.ezorm.rdb.supports.postgres.JsonbType;
-import org.jetlinks.core.metadata.DataType;
-import org.jetlinks.core.metadata.PropertyMetadata;
-import org.jetlinks.core.metadata.types.ArrayType;
-import org.jetlinks.core.metadata.types.ObjectType;
 import org.jetlinks.community.Interval;
 import org.jetlinks.community.things.data.ThingsDataConstants;
 import org.jetlinks.community.things.utils.ThingsDatabaseUtils;
 import org.jetlinks.community.timescaledb.metadata.JsonbValueCodec;
 import org.jetlinks.community.timeseries.TimeSeriesData;
 import org.jetlinks.community.timeseries.query.Aggregation;
-import org.jetlinks.community.utils.ObjectMappers;
+import org.jetlinks.core.metadata.DataType;
+import org.jetlinks.core.metadata.PropertyMetadata;
+import org.jetlinks.core.metadata.types.ArrayType;
+import org.jetlinks.core.metadata.types.ObjectType;
 import org.jetlinks.reactor.ql.utils.CastUtils;
 
 public class TimescaleDBUtils {
@@ -40,7 +39,7 @@ public class TimescaleDBUtils {
         return ThingsDatabaseUtils.createTableName(name);
     }
 
-    public static NativeSelectColumn createTimeGroupColumn(long startWith, Interval interval) {
+    public static NativeSelectColumn createTimeGroupColumn(long startWith, Interval interval, String schema) {
 
         String unit = interval.getNumber().intValue() + " " + interval
             .getUnit()
@@ -48,7 +47,7 @@ public class TimescaleDBUtils {
             .toLowerCase();
 
         return NativeSelectColumn
-            .of("time_bucket('" + unit + "',timestamp)");
+            .of(schema + "." + "time_bucket('" + unit + "',timestamp)");
     }
 
     public static TimeSeriesData convertToTimeSeriesData(Record record) {

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/impl/DefaultTimescaleDBOperations.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/impl/DefaultTimescaleDBOperations.java
@@ -103,6 +103,11 @@ public class DefaultTimescaleDBOperations implements TimescaleDBOperations, Appl
     }
 
     @Override
+    public String schema() {
+        return properties.getSchema();
+    }
+
+    @Override
     public TimescaleDBDataWriter writer() {
         return writer;
     }

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/impl/DefaultTimescaleDBOperations.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/impl/DefaultTimescaleDBOperations.java
@@ -65,7 +65,7 @@ public class DefaultTimescaleDBOperations implements TimescaleDBOperations, Appl
             database.addFeature(sqlExecutor);
             database.addFeature(ReactiveSyncSqlExecutor.of(sqlExecutor));
 
-            RDBSchemaMetadata schema = TimescaleDBDialectProvider.GLOBAL.createSchema(properties.getSchema());
+            RDBSchemaMetadata schema = TimescaleDBDialectProvider.GLOBAL.createSchema(properties.getFunctionSchema());
             database.addSchema(schema);
             database.setCurrentSchema(schema);
             this.database = DefaultDatabaseOperator.of(database);
@@ -75,7 +75,7 @@ public class DefaultTimescaleDBOperations implements TimescaleDBOperations, Appl
             }
             RDBDataSourceProperties datasource = new RDBDataSourceProperties();
             datasource.setType(RDBDataSourceProperties.Type.r2dbc);
-            datasource.setSchema(properties.getSchema());
+            datasource.setSchema(properties.getFunctionSchema());
             datasource.setUsername(properties.getR2dbc().getUsername());
             datasource.setPassword(properties.getR2dbc().getPassword());
             datasource.setUrl(properties.getR2dbc().getUrl());
@@ -103,8 +103,8 @@ public class DefaultTimescaleDBOperations implements TimescaleDBOperations, Appl
     }
 
     @Override
-    public String schema() {
-        return properties.getSchema();
+    public String functionSchema() {
+        return properties.getFunctionSchema();
     }
 
     @Override

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBColumnModeQueryOperations.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBColumnModeQueryOperations.java
@@ -28,8 +28,6 @@ import org.hswebframework.ezorm.rdb.operator.dml.query.SelectColumn;
 import org.hswebframework.web.api.crud.entity.PagerResult;
 import org.hswebframework.web.api.crud.entity.QueryParamEntity;
 import org.hswebframework.web.crud.query.QueryHelper;
-import org.jetlinks.core.metadata.EventMetadata;
-import org.jetlinks.core.things.ThingsRegistry;
 import org.jetlinks.community.things.data.AggregationRequest;
 import org.jetlinks.community.things.data.PropertyAggregation;
 import org.jetlinks.community.things.data.ThingsDataConstants;
@@ -37,17 +35,20 @@ import org.jetlinks.community.things.data.ThingsDataUtils;
 import org.jetlinks.community.things.data.operations.ColumnModeQueryOperationsBase;
 import org.jetlinks.community.things.data.operations.DataSettings;
 import org.jetlinks.community.things.data.operations.MetricBuilder;
-import org.jetlinks.community.things.data.operations.RowModeQueryOperationsBase;
 import org.jetlinks.community.timescaledb.TimescaleDBUtils;
 import org.jetlinks.community.timeseries.TimeSeriesData;
 import org.jetlinks.community.timeseries.query.Aggregation;
 import org.jetlinks.community.timeseries.query.AggregationData;
+import org.jetlinks.core.things.ThingsRegistry;
 import org.jetlinks.reactor.ql.utils.CastUtils;
 import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.function.Function;
 
 import static org.jetlinks.community.timescaledb.TimescaleDBUtils.createTimeGroupColumn;
@@ -56,15 +57,19 @@ import static org.jetlinks.community.timescaledb.TimescaleDBUtils.createTimeGrou
 public class TimescaleDBColumnModeQueryOperations extends ColumnModeQueryOperationsBase {
     private final DatabaseOperator database;
 
+    private final String schema;
+
     public TimescaleDBColumnModeQueryOperations(String thingType,
                                                 String thingTemplateId,
                                                 String thingId,
                                                 MetricBuilder metricBuilder,
                                                 DataSettings settings,
                                                 ThingsRegistry registry,
-                                                DatabaseOperator database) {
+                                                DatabaseOperator database,
+                                                String schema) {
         super(thingType, thingTemplateId, thingId, metricBuilder, settings, registry);
         this.database = database;
+        this.schema = schema;
     }
 
     @Override
@@ -104,12 +109,13 @@ public class TimescaleDBColumnModeQueryOperations extends ColumnModeQueryOperati
     protected Flux<AggregationData> doAggregation(String metric,
                                                   AggregationRequest request,
                                                   AggregationContext context) {
-        return doAggregation0(database, metric, request, context);
+        return doAggregation0(database, metric, schema, request, context);
     }
 
 
     static Flux<AggregationData> doAggregation0(DatabaseOperator database,
                                                 String metric,
+                                                String schema,
                                                 AggregationRequest request,
                                                 AggregationContext context) {
         metric = TimescaleDBUtils.getTableName(metric);
@@ -122,7 +128,8 @@ public class TimescaleDBColumnModeQueryOperations extends ColumnModeQueryOperati
         if (request.getInterval() != null) {
             NativeSelectColumn column = createTimeGroupColumn(
                 request.getFrom().getTime(),
-                request.getInterval()
+                request.getInterval(),
+                schema
             );
             query.groupBy(column);
             query.select(column);

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBColumnModeStrategy.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBColumnModeStrategy.java
@@ -71,7 +71,7 @@ public class TimescaleDBColumnModeStrategy extends AbstractThingDataRepositorySt
             context.getSettings(),
             registry,
             operations.database(),
-            operations.schema());
+            operations.functionSchema());
     }
 
     @Override

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBColumnModeStrategy.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBColumnModeStrategy.java
@@ -15,13 +15,13 @@
  */
 package org.jetlinks.community.timescaledb.thing;
 
-import org.jetlinks.community.things.data.TableSafeMetricBuilder;
-import org.jetlinks.core.things.ThingsRegistry;
 import org.jetlinks.community.things.data.AbstractThingDataRepositoryStrategy;
+import org.jetlinks.community.things.data.TableSafeMetricBuilder;
 import org.jetlinks.community.things.data.operations.DDLOperations;
 import org.jetlinks.community.things.data.operations.QueryOperations;
 import org.jetlinks.community.things.data.operations.SaveOperations;
 import org.jetlinks.community.timescaledb.TimescaleDBOperations;
+import org.jetlinks.core.things.ThingsRegistry;
 
 public class TimescaleDBColumnModeStrategy extends AbstractThingDataRepositoryStrategy {
 
@@ -70,7 +70,8 @@ public class TimescaleDBColumnModeStrategy extends AbstractThingDataRepositorySt
             TableSafeMetricBuilder.of(context.getMetricBuilder()),
             context.getSettings(),
             registry,
-            operations.database());
+            operations.database(),
+            operations.schema());
     }
 
     @Override

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBRowModeQueryOperations.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBRowModeQueryOperations.java
@@ -28,8 +28,6 @@ import org.hswebframework.ezorm.rdb.operator.dml.query.SelectColumn;
 import org.hswebframework.web.api.crud.entity.PagerResult;
 import org.hswebframework.web.api.crud.entity.QueryParamEntity;
 import org.hswebframework.web.crud.query.QueryHelper;
-import org.jetlinks.core.metadata.EventMetadata;
-import org.jetlinks.core.things.ThingsRegistry;
 import org.jetlinks.community.things.data.AggregationRequest;
 import org.jetlinks.community.things.data.PropertyAggregation;
 import org.jetlinks.community.things.data.ThingsDataConstants;
@@ -41,6 +39,7 @@ import org.jetlinks.community.timescaledb.TimescaleDBUtils;
 import org.jetlinks.community.timeseries.TimeSeriesData;
 import org.jetlinks.community.timeseries.query.Aggregation;
 import org.jetlinks.community.timeseries.query.AggregationData;
+import org.jetlinks.core.things.ThingsRegistry;
 import org.jetlinks.reactor.ql.utils.CastUtils;
 import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
@@ -49,21 +48,21 @@ import reactor.core.publisher.Mono;
 import java.util.*;
 import java.util.function.Function;
 
-import static org.jetlinks.community.timescaledb.thing.TimescaleDBColumnModeQueryOperations.doAggregation0;
-
 @Slf4j
 public class TimescaleDBRowModeQueryOperations extends RowModeQueryOperationsBase {
     private final DatabaseOperator database;
-
+    private final String schema;
     public TimescaleDBRowModeQueryOperations(String thingType,
                                              String thingTemplateId,
                                              String thingId,
                                              MetricBuilder metricBuilder,
                                              DataSettings settings,
                                              ThingsRegistry registry,
-                                             DatabaseOperator database) {
+                                             DatabaseOperator database,
+                                             String schema) {
         super(thingType, thingTemplateId, thingId, metricBuilder, settings, registry);
         this.database = database;
+        this.schema=schema;
     }
 
     @Override
@@ -117,7 +116,8 @@ public class TimescaleDBRowModeQueryOperations extends RowModeQueryOperationsBas
         if (request.getInterval() != null) {
             NativeSelectColumn column = TimescaleDBUtils.createTimeGroupColumn(
                 request.getFrom().getTime(),
-                request.getInterval()
+                request.getInterval(),
+                schema
             );
 
             query.groupBy(column);

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBRowModeStrategy.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBRowModeStrategy.java
@@ -66,7 +66,7 @@ public class TimescaleDBRowModeStrategy extends AbstractThingDataRepositoryStrat
             context.getSettings(),
             registry,
             operations.database(),
-            operations.schema());
+            operations.functionSchema());
     }
 
     @Override

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBRowModeStrategy.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBRowModeStrategy.java
@@ -15,13 +15,13 @@
  */
 package org.jetlinks.community.timescaledb.thing;
 
-import org.jetlinks.core.things.ThingsRegistry;
 import org.jetlinks.community.things.data.AbstractThingDataRepositoryStrategy;
 import org.jetlinks.community.things.data.operations.DDLOperations;
 import org.jetlinks.community.things.data.operations.QueryOperations;
 import org.jetlinks.community.things.data.operations.SaveOperations;
 import org.jetlinks.community.things.data.operations.TableSafeMetricBuilder;
 import org.jetlinks.community.timescaledb.TimescaleDBOperations;
+import org.jetlinks.core.things.ThingsRegistry;
 
 public class TimescaleDBRowModeStrategy extends AbstractThingDataRepositoryStrategy {
 
@@ -65,7 +65,8 @@ public class TimescaleDBRowModeStrategy extends AbstractThingDataRepositoryStrat
             TableSafeMetricBuilder.of(context.getMetricBuilder()),
             context.getSettings(),
             registry,
-            operations.database());
+            operations.database(),
+            operations.schema());
     }
 
     @Override

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/timeseries/TimescaleDBTimeSeriesService.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/timeseries/TimescaleDBTimeSeriesService.java
@@ -24,7 +24,6 @@ import org.hswebframework.ezorm.rdb.operator.dml.query.NativeSelectColumn;
 import org.hswebframework.ezorm.rdb.operator.dml.query.SelectColumn;
 import org.hswebframework.web.bean.FastBeanCopier;
 import org.hswebframework.web.id.IDGenerator;
-import org.jetlinks.core.utils.Reactors;
 import org.jetlinks.community.things.data.ThingsDataConstants;
 import org.jetlinks.community.timescaledb.TimescaleDBOperations;
 import org.jetlinks.community.timescaledb.TimescaleDBUtils;
@@ -32,6 +31,7 @@ import org.jetlinks.community.timeseries.TimeSeriesData;
 import org.jetlinks.community.timeseries.TimeSeriesService;
 import org.jetlinks.community.timeseries.query.*;
 import org.jetlinks.community.timeseries.utils.TimeSeriesUtils;
+import org.jetlinks.core.utils.Reactors;
 import org.jetlinks.reactor.ql.utils.CastUtils;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -113,7 +113,7 @@ public class TimescaleDBTimeSeriesService implements TimeSeriesService {
         for (Group group : groups) {
             if (group instanceof TimeGroup) {
                 _timeGroup = ((TimeGroup) group);
-                NativeSelectColumn column = TimescaleDBUtils.createTimeGroupColumn(startWith, _timeGroup.getInterval());
+                NativeSelectColumn column = TimescaleDBUtils.createTimeGroupColumn(startWith, _timeGroup.getInterval(), operations.schema());
                 column.setColumn(ThingsDataConstants.COLUMN_TIMESTAMP);
                 column.setAlias(group.getAlias());
                 query.select(column);

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/timeseries/TimescaleDBTimeSeriesService.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/timeseries/TimescaleDBTimeSeriesService.java
@@ -113,7 +113,7 @@ public class TimescaleDBTimeSeriesService implements TimeSeriesService {
         for (Group group : groups) {
             if (group instanceof TimeGroup) {
                 _timeGroup = ((TimeGroup) group);
-                NativeSelectColumn column = TimescaleDBUtils.createTimeGroupColumn(startWith, _timeGroup.getInterval(), operations.schema());
+                NativeSelectColumn column = TimescaleDBUtils.createTimeGroupColumn(startWith, _timeGroup.getInterval(), operations.functionSchema());
                 column.setColumn(ThingsDataConstants.COLUMN_TIMESTAMP);
                 column.setAlias(group.getAlias());
                 query.select(column);


### PR DESCRIPTION
- 在TimescaleDBOperations接口及实现类中添加schema()方法
- 修改TimescaleDBColumnModeQueryOperations和RowModeQueryOperations构造函数，增加schema参数
- 更新doAggregation0方法签名，传入schema参数用于时间分组查询
- 调整TimescaleDBUtils.createTimeGroupColumn方法，支持指定schema前缀 -优化TimescaleDBTimeSeriesService中的时间分组查询逻辑
- 调整类导入顺序，移除未使用的导入包