### PR TITLE
feat(notify): 添加国际化支持并优化通知管理功能

### DIFF
--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/entity/NotificationEntity.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/entity/NotificationEntity.java
@@ -27,6 +27,8 @@ import org.hswebframework.ezorm.rdb.mapping.annotation.EnumCodec;
 import org.hswebframework.web.api.crud.entity.GenericEntity;
 import org.hswebframework.web.bean.FastBeanCopier;
 import org.jetlinks.community.notify.manager.enums.NotificationState;
+import org.jetlinks.community.notify.manager.subscriber.SubscriberProvider;
+import org.jetlinks.community.notify.manager.subscriber.SubscriberProviders;
 import org.jetlinks.community.utils.ObjectMappers;
 
 import javax.persistence.Column;
@@ -37,9 +39,10 @@ import java.sql.JDBCType;
 @Getter
 @Setter
 @Table(name = "notify_notifications",
-    indexes = @Index(
-        name = "idx_ntfc_subscribe", columnList = "subscriber_type,subscriber"
-    ))
+        indexes = {
+                @Index(name = "idx_ntfc_subscribe", columnList = "subscriber_type,subscriber"),
+                @Index(name = "idx_ntfc_tp", columnList = "topic_provider")
+        })
 @Comment("消息通知信息表")
 public class NotificationEntity extends GenericEntity<String> {
     private static final long serialVersionUID = -1L;
@@ -66,6 +69,13 @@ public class NotificationEntity extends GenericEntity<String> {
     @Column(length = 64, nullable = false, updatable = false)
     @Schema(description = "主题名称")
     private String topicName;
+
+    public String getI18nTopicName() {
+        return SubscriberProviders
+                .getProvider(topicProvider)
+                .map(SubscriberProvider::getName)
+                .orElse(topicName);
+    }
 
     @Column
     @ColumnType(jdbcType = JDBCType.CLOB, javaType = String.class)

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/entity/NotifySubscriberChannelEntity.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/entity/NotifySubscriberChannelEntity.java
@@ -25,6 +25,8 @@ import org.hswebframework.ezorm.rdb.mapping.annotation.JsonCodec;
 import org.hswebframework.web.api.crud.entity.GenericEntity;
 import org.hswebframework.web.api.crud.entity.RecordCreationEntity;
 import org.hswebframework.web.crud.annotation.EnableEntityEvent;
+import org.hswebframework.web.i18n.I18nSupportUtils;
+import org.hswebframework.web.i18n.LocaleUtils;
 import org.hswebframework.web.i18n.MultipleI18nSupportEntity;
 import org.hswebframework.web.validator.CreateGroup;
 import org.jetlinks.community.authorize.AuthenticationSpec;
@@ -33,8 +35,12 @@ import org.jetlinks.community.notify.manager.subscriber.channel.NotifyChannelPro
 
 import javax.persistence.Column;
 import javax.persistence.Table;
+
 import jakarta.validation.constraints.NotBlank;
+
 import java.sql.JDBCType;
+import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -113,5 +119,17 @@ public class NotifySubscriberChannelEntity extends GenericEntity<String> impleme
 
     public String getI18nName() {
         return getI18nMessage("name", name);
+    }
+
+    public void putI18nName(String i18nKey) {
+        putI18nName(i18nKey, LocaleUtils.getSupportLocales());
+    }
+
+    public void putI18nName(String i18nKey,
+                            Collection<Locale> locales) {
+        this.i18nMessages = I18nSupportUtils
+                .putI18nMessages(
+                        i18nKey, "name", locales, null, this.i18nMessages
+                );
     }
 }

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/entity/NotifySubscriberEntity.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/entity/NotifySubscriberEntity.java
@@ -24,6 +24,8 @@ import org.hswebframework.ezorm.rdb.mapping.annotation.*;
 import org.hswebframework.web.api.crud.entity.GenericEntity;
 import org.hswebframework.web.crud.annotation.EnableEntityEvent;
 import org.jetlinks.community.notify.manager.enums.SubscribeState;
+import org.jetlinks.community.notify.manager.subscriber.SubscriberProvider;
+import org.jetlinks.community.notify.manager.subscriber.SubscriberProviders;
 import org.springframework.util.StringUtils;
 
 import javax.persistence.Column;
@@ -40,7 +42,7 @@ import java.util.Map;
  * @since 1.3
  */
 @Table(name = "notify_subscribers",
-    indexes = @Index(name = "idx_nfy_subs_subscriber", columnList = "subscriber")
+        indexes = @Index(name = "idx_nfy_subs_subscriber", columnList = "subscriber")
 )
 @Getter
 @Setter
@@ -74,9 +76,23 @@ public class NotifySubscriberEntity extends GenericEntity<String> {
     @Schema(description = "订阅名称")
     private String subscribeName;
 
+    public String getI18nSubscribeName() {
+        return SubscriberProviders
+                .getProvider(subscriber)
+                .map(SubscriberProvider::getName)
+                .orElse(subscribeName);
+    }
+
     @Column(length = 64, nullable = false)
     @Schema(description = "主题名称")
     private String topicName;
+
+    public String getI18nTopicName() {
+        return SubscriberProviders
+                .getProvider(topicProvider)
+                .map(SubscriberProvider::getName)
+                .orElse(topicName);
+    }
 
     @Column(length = 3000)
     @JsonCodec
@@ -111,9 +127,9 @@ public class NotifySubscriberEntity extends GenericEntity<String> {
 
     public String generateId() {
         if (super.getId() == null
-            && StringUtils.hasText(subscriberType)
-            && StringUtils.hasText(subscriber)
-            && StringUtils.hasText(topicProvider)) {
+                && StringUtils.hasText(subscriberType)
+                && StringUtils.hasText(subscriber)
+                && StringUtils.hasText(topicProvider)) {
             return DigestUtils.md5Hex(String.join(":", subscriberType, subscriber, topicProvider));
         }
         return null;

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/entity/NotifySubscriberProviderEntity.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/entity/NotifySubscriberProviderEntity.java
@@ -16,6 +16,7 @@
 package org.jetlinks.community.notify.manager.entity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 import org.hswebframework.ezorm.rdb.mapping.annotation.ColumnType;
@@ -29,10 +30,11 @@ import org.hswebframework.web.crud.annotation.EnableEntityEvent;
 import org.hswebframework.web.validator.CreateGroup;
 import org.jetlinks.community.authorize.AuthenticationSpec;
 import org.jetlinks.community.notify.manager.enums.NotifyChannelState;
+import org.jetlinks.community.notify.manager.subscriber.SubscriberProvider;
+import org.jetlinks.community.notify.manager.subscriber.SubscriberProviders;
 
 import javax.persistence.Column;
 import javax.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
 import java.sql.JDBCType;
 import java.util.Map;
 
@@ -54,6 +56,13 @@ public class NotifySubscriberProviderEntity extends GenericEntity<String> implem
     @NotBlank(groups = CreateGroup.class)
     @Schema(description = "名称")
     private String name;
+
+    public String getI18nName() {
+        return SubscriberProviders
+                .getProvider(provider)
+                .map(SubscriberProvider::getName)
+                .orElse(name);
+    }
 
     /**
      * @see org.jetlinks.pro.notify.subscription.SubscriberProvider#getId()

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/entity/NotifyTemplateEntity.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/entity/NotifyTemplateEntity.java
@@ -16,6 +16,8 @@
 package org.jetlinks.community.notify.manager.entity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 import org.hswebframework.ezorm.rdb.mapping.annotation.ColumnType;
@@ -26,6 +28,7 @@ import org.hswebframework.web.api.crud.entity.GenericEntity;
 import org.hswebframework.web.api.crud.entity.RecordCreationEntity;
 import org.hswebframework.web.crud.annotation.EnableEntityEvent;
 import org.hswebframework.web.crud.generator.Generators;
+import org.hswebframework.web.i18n.MultipleI18nSupportEntity;
 import org.hswebframework.web.validator.CreateGroup;
 import org.jetlinks.community.notify.template.TemplateProperties;
 import org.jetlinks.community.notify.template.VariableDefinition;
@@ -33,8 +36,6 @@ import org.jetlinks.community.notify.template.VariableDefinition;
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import java.sql.JDBCType;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +50,7 @@ import java.util.Map;
 @Table(name = "notify_template")
 @Comment("消息通知模板表")
 @EnableEntityEvent
-public class NotifyTemplateEntity extends GenericEntity<String> implements RecordCreationEntity {
+public class NotifyTemplateEntity extends GenericEntity<String> implements RecordCreationEntity, MultipleI18nSupportEntity {
     private static final long serialVersionUID = -6849794470754667710L;
 
     @Override
@@ -75,23 +76,23 @@ public class NotifyTemplateEntity extends GenericEntity<String> implements Recor
     private String name;
 
     @Column
-    @ColumnType(jdbcType = JDBCType.LONGVARCHAR,javaType = String.class)
+    @ColumnType(jdbcType = JDBCType.LONGVARCHAR, javaType = String.class)
     @JsonCodec
     @Schema(description = "模版内容(根据服务商不同而不同)")
-    private Map<String,Object> template;
+    private Map<String, Object> template;
 
     @Column(updatable = false)
     @Schema(
-        description = "创建者ID(只读)"
-        , accessMode = Schema.AccessMode.READ_ONLY
+            description = "创建者ID(只读)"
+            , accessMode = Schema.AccessMode.READ_ONLY
     )
     private String creatorId;
 
     @Column(updatable = false)
     @DefaultValue(generator = Generators.CURRENT_TIME)
     @Schema(
-        description = "创建时间(只读)"
-        , accessMode = Schema.AccessMode.READ_ONLY
+            description = "创建时间(只读)"
+            , accessMode = Schema.AccessMode.READ_ONLY
     )
     private Long createTime;
 
@@ -121,5 +122,15 @@ public class NotifyTemplateEntity extends GenericEntity<String> implements Recor
         properties.setVariableDefinitions(variableDefinitions);
         properties.setDescription(description);
         return properties;
+    }
+
+    @Schema(title = "国际化信息定义")
+    @Column
+    @JsonCodec
+    @ColumnType(jdbcType = JDBCType.LONGVARCHAR, javaType = String.class)
+    private Map<String, Map<String, String>> i18nMessages;
+
+    public String getI18nName() {
+        return getI18nMessage("name", name);
     }
 }

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/service/NotifySubscriberProviderService.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/service/NotifySubscriberProviderService.java
@@ -19,6 +19,7 @@ import lombok.AllArgsConstructor;
 import org.apache.commons.collections4.MapUtils;
 import org.hswebframework.ezorm.rdb.mapping.ReactiveRepository;
 import org.hswebframework.web.crud.service.GenericReactiveCacheSupportCrudService;
+import org.hswebframework.web.i18n.LocaleUtils;
 import org.jetlinks.community.notify.manager.entity.NotifySubscriberChannelEntity;
 import org.jetlinks.community.notify.manager.entity.NotifySubscriberProviderEntity;
 import org.jetlinks.community.notify.manager.subscriber.SubscriberProvider;
@@ -39,78 +40,83 @@ import java.util.stream.Collectors;
 @Service
 @AllArgsConstructor
 public class NotifySubscriberProviderService
-    extends GenericReactiveCacheSupportCrudService<NotifySubscriberProviderEntity, String> {
+        extends GenericReactiveCacheSupportCrudService<NotifySubscriberProviderEntity, String> {
 
     private final ReactiveRepository<NotifySubscriberChannelEntity, String> repository;
     public Mono<Void> saveInfo(Flux<NotifyChannelController.SubscriberProviderInfo> infoFlux) {
         Flux<Tuple2<NotifySubscriberProviderEntity, List<NotifySubscriberChannelEntity>>>
-            cache = infoFlux
-            .map(pro -> Tuples.of(pro.toProviderEntity(), pro.toChannelEntities()))
-            .cache();
+                cache = infoFlux
+                .map(pro -> Tuples.of(pro.toProviderEntity(), pro.toChannelEntities()))
+                .cache();
 
         return this
-            .save(cache.map(Tuple2::getT1))
-            .then(repository
-                      .save(cache.flatMapIterable(tp2 -> {
-                          //provider保存后再回填ID
-                          for (NotifySubscriberChannelEntity entity : tp2.getT2()) {
-                              entity.setProviderId(tp2.getT1().getId());
-                          }
-                          return tp2.getT2();
-                      })))
-            .then();
+                .save(cache.map(Tuple2::getT1))
+                .then(repository
+                        .save(cache.flatMapIterable(tp2 -> {
+                            //provider保存后再回填ID
+                            for (NotifySubscriberChannelEntity entity : tp2.getT2()) {
+                                entity.setProviderId(tp2.getT1().getId());
+                            }
+                            return tp2.getT2();
+                        })))
+                .then();
     }
 
-
-    //获取所有通道配置
+    /**
+     * 获取所有订阅提供商(在此过程中自动更新数据库数据)
+     *
+     * @return 订阅提供商
+     */
     public Flux<NotifyChannelController.SubscriberProviderInfo> channels() {
 
         Map<String, NotifyChannelController.SubscriberProviderInfo> info = SubscriberProviders
-            .getProviders()
-            .stream()
-            .collect(Collectors.toMap(
-                SubscriberProvider::getId,
-                NotifyChannelController.SubscriberProviderInfo::of));
+                .getProviders()
+                .stream()
+                .collect(Collectors.toMap(
+                        SubscriberProvider::getId,
+                        NotifyChannelController.SubscriberProviderInfo::of));
 
         Map<String, NotifyChannelController.SubscriberProviderInfo> notSaveInfoMap = new HashMap<>(info);
         return createQuery()
-            .fetch()
-            .collectList()
-            .flatMap(providers -> {
-                Map<String, NotifyChannelController.SubscriberProviderInfo> providerInfoMap = new HashMap<>();
-                for (NotifySubscriberProviderEntity provider : providers) {
-                    NotifyChannelController.SubscriberProviderInfo channelInfo = info.get(provider.getProvider());
-                    if (channelInfo != null) {
-                        channelInfo.with(provider);
-                        providerInfoMap.put(channelInfo.getId(), channelInfo);
-                    }
-                    if (info.get(provider.getProvider()) != null) {
-                        notSaveInfoMap.remove(provider.getProvider());
-                    }
-                }
-                if (!MapUtils.isEmpty(notSaveInfoMap)) {
-                    List<NotifySubscriberProviderEntity> providerList = notSaveInfoMap
-                        .values()
-                        .stream()
-                        .map(NotifyChannelController.SubscriberProviderInfo::toProviderEntity)
-                        .collect(Collectors.toList());
-                    return save(providerList)
-                        .thenReturn(providerInfoMap);
-                }
-                return Mono.just(providerInfoMap);
-            })
-            .filter(MapUtils::isNotEmpty)
-            .flatMapMany(mapping -> repository
-                .createQuery()
-                .in(NotifySubscriberChannelEntity::getProviderId, mapping.keySet())
                 .fetch()
-                .doOnNext(channel -> {
-                    NotifyChannelController.SubscriberProviderInfo channelInfo = mapping.get(channel.getProviderId());
-                    if (channelInfo != null) {
-                        channelInfo.with(channel);
+                .as(LocaleUtils::transform)
+                .collectList()
+                .flatMap(providers -> {
+                    Map<String, NotifyChannelController.SubscriberProviderInfo> providerInfoMap = new HashMap<>();
+                    for (NotifySubscriberProviderEntity provider : providers) {
+                        NotifyChannelController.SubscriberProviderInfo channelInfo = info.get(provider.getProvider());
+                        if (channelInfo != null) {
+                            channelInfo.with(provider);
+                            providerInfoMap.put(channelInfo.getId(), channelInfo);
+                        }
+                        if (info.get(provider.getProvider()) != null) {
+                            notSaveInfoMap.remove(provider.getProvider());
+                        }
                     }
-                }))
-            .thenMany(Flux.fromIterable(info.values()))
-            .sort(Comparator.comparing(NotifyChannelController.SubscriberProviderInfo::getOrder));
+                    if (!MapUtils.isEmpty(notSaveInfoMap)) {
+                        List<NotifySubscriberProviderEntity> providerList = notSaveInfoMap
+                                .values()
+                                .stream()
+                                .map(NotifyChannelController.SubscriberProviderInfo::toProviderEntity)
+                                .collect(Collectors.toList());
+                        return save(providerList)
+                                .thenReturn(providerInfoMap);
+                    }
+                    return Mono.just(providerInfoMap);
+                })
+                .filter(MapUtils::isNotEmpty)
+                .flatMapMany(mapping -> repository
+                        .createQuery()
+                        .in(NotifySubscriberChannelEntity::getProviderId, mapping.keySet())
+                        .fetch()
+                        .doOnNext(channel -> {
+                            channel.putI18nName("message.subscriber.provider." + channel.getChannelProvider());
+                            NotifyChannelController.SubscriberProviderInfo channelInfo = mapping.get(channel.getProviderId());
+                            if (channelInfo != null) {
+                                channelInfo.with(channel);
+                            }
+                        }))
+                .thenMany(Flux.fromIterable(info.values()))
+                .sort(Comparator.comparing(NotifyChannelController.SubscriberProviderInfo::getOrder));
     }
 }

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/SubscriberProvider.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/SubscriberProvider.java
@@ -19,6 +19,7 @@ import org.hswebframework.web.authorization.Authentication;
 import org.jetlinks.community.notify.enums.SubscriberTypeEnum;
 import org.jetlinks.community.notify.subscription.SubscribeType;
 import org.jetlinks.core.Wrapper;
+import org.jetlinks.community.notify.manager.enums.NotifyChannelState;
 import org.jetlinks.core.metadata.ConfigMetadata;
 import org.jetlinks.core.metadata.PropertyMetadata;
 import reactor.core.publisher.Flux;
@@ -42,6 +43,14 @@ public interface SubscriberProvider extends Wrapper {
      * @return 名称
      */
     String getName();
+
+    default NotifyChannelState getState(NotifyChannelState state) {
+        return state == null ? getDefaultState() : state;
+    }
+
+    default NotifyChannelState getDefaultState() {
+        return NotifyChannelState.disabled;
+    }
 
     /**
      * return 排序

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/channel/notifiers/NotifierChannelProvider.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/channel/notifiers/NotifierChannelProvider.java
@@ -17,21 +17,22 @@ package org.jetlinks.community.notify.manager.subscriber.channel.notifiers;
 
 import com.alibaba.fastjson.JSON;
 import com.google.common.collect.Maps;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.collections4.MapUtils;
 import org.hswebframework.web.bean.FastBeanCopier;
+import org.hswebframework.web.i18n.LocaleUtils;
 import org.hswebframework.web.validator.ValidatorUtils;
-import org.jetlinks.core.Values;
 import org.jetlinks.community.notify.NotifierManager;
 import org.jetlinks.community.notify.NotifyType;
 import org.jetlinks.community.notify.manager.entity.Notification;
 import org.jetlinks.community.notify.manager.subscriber.channel.NotifyChannel;
 import org.jetlinks.community.notify.manager.subscriber.channel.NotifyChannelProvider;
+import org.jetlinks.core.Values;
 import reactor.core.publisher.Mono;
 
-import jakarta.validation.constraints.NotBlank;
 import java.util.Map;
 
 @AllArgsConstructor
@@ -48,7 +49,8 @@ public abstract class NotifierChannelProvider implements NotifyChannelProvider {
 
     @Override
     public String getName() {
-        return getNotifyType().getName();
+        return LocaleUtils
+                .resolveMessage("org.jetlinks.community.notify.DefaultNotifyType." + getNotifyType().getId(), getNotifyType().getName());
     }
 
     @Override
@@ -121,8 +123,8 @@ public abstract class NotifierChannelProvider implements NotifyChannelProvider {
         @Override
         public Mono<Void> sendNotify(Notification notification) {
             return notifierManager
-                .getNotifier(getNotifyType(), config.notifierId)
-                .flatMap(notifier -> notifier.send(config.templateId, Values.of(createVariable(notification))));
+                    .getNotifier(getNotifyType(), config.notifierId)
+                    .flatMap(notifier -> notifier.send(config.templateId, Values.of(createVariable(notification))));
         }
 
         @Override

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/providers/AlarmDeviceProvider.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/providers/AlarmDeviceProvider.java
@@ -18,6 +18,7 @@ package org.jetlinks.community.notify.manager.subscriber.providers;
 import lombok.extern.slf4j.Slf4j;
 import org.hswebframework.web.authorization.Authentication;
 import org.hswebframework.web.i18n.LocaleUtils;
+import org.jetlinks.community.notify.manager.enums.NotifyChannelState;
 import org.jetlinks.community.notify.manager.subscriber.Subscriber;
 import org.jetlinks.community.topic.Topics;
 import org.jetlinks.core.event.EventBus;
@@ -34,24 +35,31 @@ import java.util.Map;
 @Slf4j
 public class AlarmDeviceProvider extends AlarmProvider {
 
+    public static final String provider = "alarm-device";
+
     public AlarmDeviceProvider(EventBus eventBus) {
         super(eventBus);
     }
 
     @Override
     public String getId() {
-        return "alarm-device";
+        return provider;
     }
 
     @Override
     public String getName() {
         return LocaleUtils
-            .resolveMessage("message.subscriber.provider.alarm-device", "设备告警");
+                .resolveMessage("message.subscriber.provider.alarm-device", "设备告警");
     }
 
     @Override
     public Integer getOrder() {
         return 100;
+    }
+
+    @Override
+    public NotifyChannelState getDefaultState() {
+        return NotifyChannelState.enabled;
     }
 
     @Override
@@ -63,10 +71,10 @@ public class AlarmDeviceProvider extends AlarmProvider {
     @Override
     public Flux<PropertyMetadata> getDetailProperties(Map<String, Object> config) {
         return super.getDetailProperties(config)
-            .concatWith(Flux.just(
-                SimplePropertyMetadata.of("targetId", "设备ID", StringType.GLOBAL),
-                SimplePropertyMetadata.of("targetName", "设备名称", StringType.GLOBAL)
-            ));
+                    .concatWith(Flux.just(
+                            SimplePropertyMetadata.of("targetId", "设备ID", StringType.GLOBAL),
+                            SimplePropertyMetadata.of("targetName", "设备名称", StringType.GLOBAL)
+                    ));
     }
 
 }

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/providers/AlarmProductProvider.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/providers/AlarmProductProvider.java
@@ -18,6 +18,7 @@ package org.jetlinks.community.notify.manager.subscriber.providers;
 import lombok.extern.slf4j.Slf4j;
 import org.hswebframework.web.authorization.Authentication;
 import org.hswebframework.web.i18n.LocaleUtils;
+import org.jetlinks.community.notify.manager.enums.NotifyChannelState;
 import org.jetlinks.community.notify.manager.subscriber.Subscriber;
 import org.jetlinks.community.topic.Topics;
 import org.jetlinks.core.event.EventBus;
@@ -34,24 +35,31 @@ import java.util.Map;
 @Slf4j
 public class AlarmProductProvider extends AlarmProvider {
 
+    public static final String provider = "alarm-product";
+
     public AlarmProductProvider(EventBus eventBus) {
         super(eventBus);
     }
 
     @Override
     public String getId() {
-        return "alarm-product";
+        return provider;
     }
 
     @Override
     public String getName() {
         return LocaleUtils
-            .resolveMessage("message.subscriber.provider.alarm-product", "产品告警");
+                .resolveMessage("message.subscriber.provider.alarm-product", "产品告警");
     }
 
     @Override
     public Integer getOrder() {
         return -100;
+    }
+
+    @Override
+    public NotifyChannelState getDefaultState() {
+        return NotifyChannelState.enabled;
     }
 
     @Override
@@ -63,9 +71,9 @@ public class AlarmProductProvider extends AlarmProvider {
     @Override
     public Flux<PropertyMetadata> getDetailProperties(Map<String, Object> config) {
         return super.getDetailProperties(config)
-            .concatWith(Flux.just(
-                SimplePropertyMetadata.of("targetId", "产品ID", StringType.GLOBAL),
-                SimplePropertyMetadata.of("targetName", "产品名称", StringType.GLOBAL)
-            ));
+                    .concatWith(Flux.just(
+                            SimplePropertyMetadata.of("targetId", "产品ID", StringType.GLOBAL),
+                            SimplePropertyMetadata.of("targetName", "产品名称", StringType.GLOBAL)
+                    ));
     }
 }

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/providers/AlarmProvider.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/providers/AlarmProvider.java
@@ -49,7 +49,9 @@ import java.util.Objects;
 @Slf4j
 public class AlarmProvider implements SubscriberProvider {
 
-    private final EventBus eventBus;
+    public static final String provider = "alarm";
+
+    protected final EventBus eventBus;
 
     public AlarmProvider(EventBus eventBus) {
         this.eventBus = eventBus;
@@ -57,7 +59,7 @@ public class AlarmProvider implements SubscriberProvider {
 
     @Override
     public String getId() {
-        return "alarm";
+        return provider;
     }
 
     @Override
@@ -80,10 +82,10 @@ public class AlarmProvider implements SubscriberProvider {
     @Override
     public ConfigMetadata getConfigMetadata() {
         return new DefaultConfigMetadata()
-            .add("alarmConfigId", "告警规则", "告警规则,支持通配符:*", StringType.GLOBAL);
+                .add("alarmConfigId", "告警规则", "告警规则,支持通配符:*", StringType.GLOBAL);
     }
 
-    protected String getAlarmId(Map<String, Object> config) {
+    protected String getAlarmId( Map<String, Object> config) {
         ValueObject configs = ValueObject.of(config);
         return configs.getString("alarmConfigId").orElse("*");
     }
@@ -92,8 +94,8 @@ public class AlarmProvider implements SubscriberProvider {
                                                   Authentication authentication,
                                                   String topic) {
         return Mono.just(locale -> createSubscribe(locale, id, new String[]{topic})
-            //有效期内去重,防止同一个用户所在多个部门推送同一个告警
-            .as(FluxUtils.distinct(Notify::getDataId, Duration.ofSeconds(10))));
+                //有效期内去重,防止同一个用户所在多个部门推送同一个告警
+                .as(FluxUtils.distinct(Notify::getDataId, Duration.ofSeconds(10))));
     }
 
     private Flux<Notify> createSubscribe(Locale locale,

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/providers/AlarmSceneProvider.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/subscriber/providers/AlarmSceneProvider.java
@@ -18,6 +18,8 @@ package org.jetlinks.community.notify.manager.subscriber.providers;
 import lombok.extern.slf4j.Slf4j;
 import org.hswebframework.web.authorization.Authentication;
 import org.hswebframework.web.i18n.LocaleUtils;
+import org.hswebframework.web.i18n.LocaleUtils;
+import org.jetlinks.community.notify.manager.enums.NotifyChannelState;
 import org.jetlinks.community.notify.manager.subscriber.Subscriber;
 import org.jetlinks.community.topic.Topics;
 import org.jetlinks.core.event.EventBus;
@@ -30,13 +32,15 @@ import java.util.Map;
 @Slf4j
 public class AlarmSceneProvider extends AlarmProvider {
 
+    public static final String provider = "alarm-other";
+
     public AlarmSceneProvider(EventBus eventBus) {
         super(eventBus);
     }
 
     @Override
     public String getId() {
-        return "alarm-other";
+        return provider;
     }
 
     @Override
@@ -48,6 +52,11 @@ public class AlarmSceneProvider extends AlarmProvider {
     @Override
     public Integer getOrder() {
         return 300;
+    }
+
+    @Override
+    public NotifyChannelState getDefaultState() {
+        return NotifyChannelState.enabled;
     }
 
     @Override

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/web/NotificationController.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/web/NotificationController.java
@@ -63,7 +63,7 @@ public class NotificationController {
     public NotificationController(NotificationService notificationService,
                                   NotifySubscriberService subscriberService,
                                   NotifySubscriberProviderService providerService,
-                                  NotifySubscriberProperties properties) {
+                                  NotifySubscriberProperties properties ) {
         this.notificationService = notificationService;
         this.subscriberService = subscriberService;
         this.providerService = providerService;
@@ -75,13 +75,13 @@ public class NotificationController {
     @QueryOperation(summary = "查询当前用户订阅信息")
     public Mono<PagerResult<NotifySubscriberEntity>> querySubscription(@Parameter(hidden = true) QueryParamEntity query) {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMap(auth -> query
-                .toNestQuery(q -> q
-                    .where(NotifySubscriberEntity::getSubscriberType, "user")
-                    .and(NotifySubscriberEntity::getSubscriber, auth.getUser().getId()))
-                .execute(subscriberService::queryPager));
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .flatMap(auth -> query
+                        .toNestQuery(q -> q
+                                .where(NotifySubscriberEntity::getSubscriberType, "user")
+                                .and(NotifySubscriberEntity::getSubscriber, auth.getUser().getId()))
+                        .execute(subscriberService::queryPager));
 
     }
 
@@ -97,17 +97,17 @@ public class NotificationController {
     @Operation(summary = "修改通知订阅状态")
     public Mono<Void> changeSubscribeState(@PathVariable String id, @PathVariable SubscribeState state) {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMap(auth -> subscriberService
-                .createUpdate()
-                .set(NotifySubscriberEntity::getState, state)
-                .where(NotifySubscriberEntity::getId, id)
-                .and(NotifySubscriberEntity::getSubscriber, auth.getUser().getId())
-                .and(NotifySubscriberEntity::getSubscriberType, "user")
-                .execute()
-                .then()
-            );
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .flatMap(auth -> subscriberService
+                        .createUpdate()
+                        .set(NotifySubscriberEntity::getState, state)
+                        .where(NotifySubscriberEntity::getId, id)
+                        .and(NotifySubscriberEntity::getSubscriber, auth.getUser().getId())
+                        .and(NotifySubscriberEntity::getSubscriberType, "user")
+                        .execute()
+                        .then()
+                );
     }
 
     @DeleteMapping("/subscription/{id}")
@@ -115,16 +115,16 @@ public class NotificationController {
     @Operation(summary = "删除订阅")
     public Mono<Void> deleteSubscription(@PathVariable String id) {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMap(auth -> subscriberService
-                .createDelete()
-                .where(NotifySubscriberEntity::getId, id)
-                .and(NotifySubscriberEntity::getSubscriber, auth.getUser().getId())
-                .and(NotifySubscriberEntity::getSubscriberType, "user")
-                .execute()
-                .then()
-            );
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .flatMap(auth -> subscriberService
+                        .createDelete()
+                        .where(NotifySubscriberEntity::getId, id)
+                        .and(NotifySubscriberEntity::getSubscriber, auth.getUser().getId())
+                        .and(NotifySubscriberEntity::getSubscriberType, "user")
+                        .execute()
+                        .then()
+                );
     }
 
     @PatchMapping("/subscribe")
@@ -132,16 +132,16 @@ public class NotificationController {
     @Operation(summary = "订阅通知")
     public Flux<NotifySubscriberEntity> doSubscribe(@RequestBody Flux<NotifySubscriberEntity> subscribe) {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMapMany(auth -> subscribe
-                .doOnNext(e -> {
-                    e.setSubscriberType("user");
-                    e.setSubscriber(auth.getUser().getId());
-                })
-                .flatMap(e -> subscriberService
-                    .doSubscribe(e)
-                    .thenReturn(e)));
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .flatMapMany(auth -> subscribe
+                        .doOnNext(e -> {
+                            e.setSubscriberType("user");
+                            e.setSubscriber(auth.getUser().getId());
+                        })
+                        .flatMap(e -> subscriberService
+                                .doSubscribe(e)
+                                .thenReturn(e)));
     }
 
     /**
@@ -153,8 +153,8 @@ public class NotificationController {
     @Operation(summary = "获取全部订阅支持")
     public Flux<SubscriberProviderInfo> getProviders() {
         return Flux
-            .fromIterable(SubscriberProviders.getProviders())
-            .map(SubscriberProviderInfo::of);
+                .fromIterable(SubscriberProviders.getProviders())
+                .map(SubscriberProviderInfo::of);
     }
 
     /**
@@ -166,18 +166,18 @@ public class NotificationController {
     @Operation(summary = "获取当前用户可用的订阅支持")
     public Flux<SubscriberProviderInfo> getCurrentProviders() {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMapMany(auth -> providerService
-                .channels()
-                .mapNotNull(info -> info.copyToProvidedUser(auth, properties)))
-            .filter(p -> CollectionUtils.isNotEmpty(p.getChannels()))
-            .map(NotifyChannelController.SubscriberProviderInfo::getProvider)
-            .collectList()
-            .flatMapMany(providers -> Flux
-                .fromIterable(SubscriberProviders.getProviders())
-                .filter(provider -> providers.contains(provider.getId()))
-                .map(SubscriberProviderInfo::of));
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .flatMapMany(auth -> providerService
+                        .channels()
+                        .mapNotNull(info -> info.copyToProvidedUser(auth, properties)))
+                .filter(p -> CollectionUtils.isNotEmpty(p.getChannels()))
+                .map(NotifyChannelController.SubscriberProviderInfo::getProvider)
+                .collectList()
+                .flatMapMany(providers -> Flux
+                        .fromIterable(SubscriberProviders.getProviders())
+                        .filter(provider -> providers.contains(provider.getId()))
+                        .map(SubscriberProviderInfo::of));
     }
 
     /**
@@ -189,19 +189,19 @@ public class NotificationController {
     @Operation(summary = "根据订阅类型获取当前用户可用的订阅支持")
     public Flux<SubscriberProviderInfo> getCurrentProviders(@PathVariable String type) {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMapMany(auth -> providerService
-                .channels()
-                .mapNotNull(info -> info.copyToProvidedUser(auth, properties)))
-            .filter(p -> CollectionUtils.isNotEmpty(p.getChannels()))
-            .map(NotifyChannelController.SubscriberProviderInfo::getProvider)
-            .collectList()
-            .flatMapMany(providers -> Flux
-                .fromIterable(SubscriberProviders.getProviders())
-                .filter(provider -> provider.getType().getId().equals(type) && providers.contains(provider.getId()))
-                .sort(Comparator.comparing(SubscriberProvider::getOrder))
-                .map(SubscriberProviderInfo::of));
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .flatMapMany(auth -> providerService
+                        .channels()
+                        .mapNotNull(info -> info.copyToProvidedUser(auth, properties)))
+                .filter(p -> CollectionUtils.isNotEmpty(p.getChannels()))
+                .map(NotifyChannelController.SubscriberProviderInfo::getProvider)
+                .collectList()
+                .flatMapMany(providers -> Flux
+                        .fromIterable(SubscriberProviders.getProviders())
+                        .filter(provider -> provider.getType().getId().equals(type) && providers.contains(provider.getId()))
+                        .sort(Comparator.comparing(SubscriberProvider::getOrder))
+                        .map(SubscriberProviderInfo::of));
     }
 
     @GetMapping("/_query")
@@ -209,14 +209,14 @@ public class NotificationController {
     @QueryOperation(summary = "查询通知记录")
     public Mono<PagerResult<NotificationEntity>> queryMyNotifications(@Parameter(hidden = true) QueryParamEntity query) {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMap(auth -> query
-                .toNestQuery(q -> q
-                    .where(NotificationEntity::getSubscriberType, "user")
-                    .and(NotificationEntity::getSubscriber, auth.getUser().getId()))
-                .execute(notificationService::queryPager)
-                .defaultIfEmpty(PagerResult.empty()));
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .flatMap(auth -> query
+                        .toNestQuery(q -> q
+                                .where(NotificationEntity::getSubscriberType, "user")
+                                .and(NotificationEntity::getSubscriber, auth.getUser().getId()))
+                        .execute(notificationService::queryPager)
+                        .defaultIfEmpty(PagerResult.empty()));
 
     }
 
@@ -232,16 +232,16 @@ public class NotificationController {
     @QueryOperation(summary = "获取通知记录")
     public Mono<NotificationEntity> readNotification(@PathVariable String id) {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMap(auth -> QueryParamEntity
-                .newQuery()
-                .where(NotificationEntity::getSubscriberType, "user")
-                .and(NotificationEntity::getSubscriber, auth.getUser().getId())
-                .and(NotificationEntity::getId, id)
-                .execute(notificationService::findAndMarkRead)
-                .singleOrEmpty()
-            );
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .flatMap(auth -> QueryParamEntity
+                        .newQuery()
+                        .where(NotificationEntity::getSubscriberType, "user")
+                        .and(NotificationEntity::getSubscriber, auth.getUser().getId())
+                        .and(NotificationEntity::getId, id)
+                        .execute(notificationService::findAndMarkRead)
+                        .singleOrEmpty()
+                );
     }
 
     @PostMapping("/_{state}")
@@ -250,18 +250,18 @@ public class NotificationController {
     public Mono<Integer> readNotification(@RequestBody Mono<List<String>> idList,
                                           @PathVariable NotificationState state) {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMap(auth -> idList
-                .filter(CollectionUtils::isNotEmpty)
-                .flatMap(list -> notificationService
-                    .createUpdate()
-                    .set(NotificationEntity::getState, state)
-                    .where(NotificationEntity::getSubscriberType, "user")
-                    .and(NotificationEntity::getSubscriber, auth.getUser().getId())
-                    .in(NotificationEntity::getId, list)
-                    .execute())
-            );
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .flatMap(auth -> idList
+                        .filter(CollectionUtils::isNotEmpty)
+                        .flatMap(list -> notificationService
+                                .createUpdate()
+                                .set(NotificationEntity::getState, state)
+                                .where(NotificationEntity::getSubscriberType, "user")
+                                .and(NotificationEntity::getSubscriber, auth.getUser().getId())
+                                .in(NotificationEntity::getId, list)
+                                .execute())
+                );
     }
 
     @PostMapping("/_{state}/provider")
@@ -270,18 +270,18 @@ public class NotificationController {
     public Mono<Integer> readNotificationByType(@RequestBody Mono<List<String>> providerList,
                                                 @PathVariable NotificationState state) {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMap(auth -> providerList
-                .filter(CollectionUtils::isNotEmpty)
-                .flatMap(list -> notificationService
-                    .createUpdate()
-                    .set(NotificationEntity::getState, state)
-                    .where(NotificationEntity::getSubscriberType, "user")
-                    .and(NotificationEntity::getSubscriber, auth.getUser().getId())
-                    .in(NotificationEntity::getTopicProvider, list)
-                    .execute())
-            );
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .flatMap(auth -> providerList
+                        .filter(CollectionUtils::isNotEmpty)
+                        .flatMap(list -> notificationService
+                                .createUpdate()
+                                .set(NotificationEntity::getState, state)
+                                .where(NotificationEntity::getSubscriberType, "user")
+                                .and(NotificationEntity::getSubscriber, auth.getUser().getId())
+                                .in(NotificationEntity::getTopicProvider, list)
+                                .execute())
+                );
     }
 
     @Getter

--- a/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/web/NotifyChannelController.java
+++ b/jetlinks-manager/notify-manager/src/main/java/org/jetlinks/community/notify/manager/web/NotifyChannelController.java
@@ -30,6 +30,7 @@ import org.hswebframework.web.authorization.annotation.DeleteAction;
 import org.hswebframework.web.authorization.annotation.Resource;
 import org.hswebframework.web.authorization.annotation.SaveAction;
 import org.hswebframework.web.authorization.exception.UnAuthorizedException;
+import org.hswebframework.web.i18n.LocaleUtils;
 import org.hswebframework.web.id.IDGenerator;
 import org.jetlinks.community.authorize.AuthenticationSpec;
 import org.jetlinks.community.notify.manager.configuration.NotifySubscriberProperties;
@@ -70,8 +71,8 @@ public class NotifyChannelController {
     @Operation(summary = "获取通知通道提供商信息")
     public Flux<NotifyChannelProviderInfo> getChannelProviders() {
         return Flux
-            .fromIterable(channelProviders)
-            .map(NotifyChannelProviderInfo::of);
+                .fromIterable(channelProviders)
+                .map(NotifyChannelProviderInfo::of);
     }
 
 
@@ -88,8 +89,8 @@ public class NotifyChannelController {
     public Mono<Void> saveChannel(@PathVariable String providerId,
                                   @RequestBody Flux<NotifySubscriberChannelEntity> channels) {
         return repository
-            .save(channels.doOnNext(c -> c.setProviderId(providerId)))
-            .then();
+                .save(channels.doOnNext(c -> c.setProviderId(providerId)))
+                .then();
     }
 
     @DeleteMapping("/{channelId}")
@@ -97,8 +98,8 @@ public class NotifyChannelController {
     @Operation(summary = "删除通道")
     public Mono<Void> saveChannel(@PathVariable String channelId) {
         return repository
-            .deleteById(channelId)
-            .then();
+                .deleteById(channelId)
+                .then();
     }
 
     @PostMapping("/{providerId}/enable")
@@ -106,12 +107,12 @@ public class NotifyChannelController {
     @SaveAction
     public Mono<Void> enableProvider(@PathVariable String providerId) {
         return providerService
-            .findById(providerId)
-            .flatMap(provider -> {
-                provider.setState(NotifyChannelState.enabled);
-                return providerService.updateById(providerId, provider);
-            })
-            .then();
+                .findById(providerId)
+                .flatMap(provider -> {
+                    provider.setState(NotifyChannelState.enabled);
+                    return providerService.updateById(providerId, provider);
+                })
+                .then();
     }
 
     @PostMapping("/{providerId}/disable")
@@ -119,12 +120,12 @@ public class NotifyChannelController {
     @SaveAction
     public Mono<Void> disableProvider(@PathVariable String providerId) {
         return providerService
-            .findById(providerId)
-            .flatMap(provider -> {
-                provider.setState(NotifyChannelState.disabled);
-                return providerService.updateById(providerId, provider);
-            })
-            .then();
+                .findById(providerId)
+                .flatMap(provider -> {
+                    provider.setState(NotifyChannelState.disabled);
+                    return providerService.updateById(providerId, provider);
+                })
+                .then();
     }
 
     @PutMapping("/{providerId}")
@@ -133,8 +134,8 @@ public class NotifyChannelController {
     public Mono<Void> updateProvider(@PathVariable String providerId,
                                      @RequestBody Mono<NotifySubscriberProviderEntity> provider) {
         return providerService
-            .updateById(providerId, provider)
-            .then();
+                .updateById(providerId, provider)
+                .then();
     }
 
     @GetMapping("/all-for-save")
@@ -149,10 +150,11 @@ public class NotifyChannelController {
     @Operation(summary = "获取当前用户可访问的通道配置")
     public Flux<SubscriberProviderInfo> accessibleChannels() {
         return Authentication
-            .currentReactive()
-            .switchIfEmpty(Mono.error(UnAuthorizedException::new))
-            .flatMapMany(auth -> channels().mapNotNull(info -> info.copyToProvidedUser(auth, properties)))
-            .filter(p -> CollectionUtils.isNotEmpty(p.getChannels()));
+                .currentReactive()
+                .switchIfEmpty(Mono.error(UnAuthorizedException::new))
+                .as(LocaleUtils::transform)
+                .flatMapMany(auth -> channels().mapNotNull(info -> info.copyToProvidedUser(auth, properties)))
+                .filter(p -> CollectionUtils.isNotEmpty(p.getChannels()));
     }
 
     @GetMapping("/{providerId}/variables")
@@ -160,10 +162,10 @@ public class NotifyChannelController {
     @Operation(summary = "获取通知的内置参数")
     public Flux<PropertyMetadata> notifyVariables(@PathVariable String providerId) {
         return providerService
-            .findById(providerId)
-            .flatMapMany(entity -> Mono
-                .justOrEmpty(SubscriberProviders.getProvider(entity.getProvider()))
-                .flatMapMany(provider -> provider.getDetailProperties(entity.getConfiguration())));
+                .findById(providerId)
+                .flatMapMany(entity -> Mono
+                        .justOrEmpty(SubscriberProviders.getProvider(entity.getProvider()))
+                        .flatMapMany(provider -> provider.getDetailProperties(entity.getConfiguration())));
     }
 
     @Getter
@@ -175,6 +177,13 @@ public class NotifyChannelController {
         private String id;
 
         private String name;
+
+        public String getI18nName() {
+            return SubscriberProviders
+                    .getProvider(provider)
+                    .map(SubscriberProvider::getName)
+                    .orElse(name);
+        }
 
         private String provider;
 
@@ -210,8 +219,8 @@ public class NotifyChannelController {
 
         public SubscriberProviderInfo copyToProvidedUser(Authentication auth, NotifySubscriberProperties properties) {
             if (id == null
-                || (state == null || state == NotifyChannelState.disabled)
-                || (!properties.isAllowAllNotify(auth) && grant != null && !grant.isGranted(auth))) {
+                    || (state == null || state == NotifyChannelState.disabled)
+                    || (!properties.isAllowAllNotify(auth) && grant != null && !grant.isGranted(auth))) {
                 return null;
             }
 
@@ -221,31 +230,31 @@ public class NotifyChannelController {
             info.setProvider(provider);
             info.setType(type);
             info.setChannels(
-                channels
-                    .stream()
-                    .filter(channel -> (
-                        (channel.getId() != null)
-                            && (
-                            properties.isAllowAllNotify(auth)
-                                || (channel.getGrant() != null && channel.getGrant().isGranted(auth))
-                        )
-                    ))
-                    .collect(Collectors.toList())
+                    channels
+                            .stream()
+                            .filter(channel -> (
+                                    (channel.getId() != null)
+                                            && (
+                                            properties.isAllowAllNotify(auth)
+                                                    || (channel.getGrant() != null && channel.getGrant().isGranted(auth))
+                                    )
+                            ))
+                            .collect(Collectors.toList())
             );
             return info;
         }
 
         public static SubscriberProviderInfo of(SubscriberProvider info) {
             return new SubscriberProviderInfo(
-                IDGenerator.RANDOM.generate(),
-                info.getName(),
-                info.getId(),
-                SubscribeTypeInfo.of(info.getType()),
-                null,
-                null,
-                NotifyChannelState.disabled,
-                new ArrayList<>(),
-                info.getOrder()
+                    IDGenerator.RANDOM.generate(),
+                    info.getName(),
+                    info.getId(),
+                    SubscribeTypeInfo.of(info.getType()),
+                    null,
+                    null,
+                    NotifyChannelState.disabled,
+                    new ArrayList<>(),
+                    info.getOrder()
             );
         }
 
@@ -264,7 +273,7 @@ public class NotifyChannelController {
             boolean matched = false;
             for (NotifySubscriberChannelEntity entity : channels) {
                 if (Objects.equals(entity.getChannelProvider(), channel.getChannelProvider())
-                    && entity.getId() == null) {
+                        && entity.getId() == null) {
                     matched = true;
                     channel.copyTo(entity);
                 }
@@ -277,6 +286,10 @@ public class NotifyChannelController {
 
         public SubscriberProviderInfo with(NotifySubscriberProviderEntity provider) {
             this.id = provider.getId();
+
+            //这里用翻译后的
+            this.name = provider.getI18nName();
+
             this.grant = provider.getGrant();
             this.provider = provider.getProvider();
             this.configuration = provider.getConfiguration();


### PR DESCRIPTION
- 在NotificationEntity中添加i18nTopicName方法实现国际化主题名称
- 在NotifySubscriberChannelEntity中添加i18nName相关方法支持国际化
- 在NotifySubscriberEntity中添加i18nSubscribeName和i18nTopicName方法
- 在NotifySubscriberProviderEntity中添加i18nName方法
- 在NotifyTemplateEntity中实现MultipleI18nSupportEntity接口并添加国际化字段
- 为AlarmDeviceProvider、AlarmProductProvider和AlarmSceneProvider添加默认启用状态
- 在SubscriberProvider接口中添加默认状态相关方法
- 优化NotifySubscriberProviderService中的国际化处理逻辑
- 为NotifierChannelProvider添加国际化名称解析功能
- 更新NotificationController和NotifyChannelController中的相关逻辑以支持国际化