### PR TITLE
fix: support Timestamp conversion in CommonConfiguration

### DIFF
--- a/jetlinks-components/common-component/src/main/java/org/jetlinks/community/configuration/CommonConfiguration.java
+++ b/jetlinks-components/common-component/src/main/java/org/jetlinks/community/configuration/CommonConfiguration.java
@@ -78,6 +78,7 @@ import reactor.core.publisher.Hooks;
 import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.sql.Timestamp;
 import java.util.Date;
 import java.util.Map;
 
@@ -140,6 +141,37 @@ public class CommonConfiguration {
                 return (T) TimeUtils.parseUnit(String.valueOf(value));
             }
         }, ChronoUnit.class);
+
+        BeanUtilsBean.getInstance().getConvertUtils().register(new Converter() {
+            @Override
+            @Generated
+            public <T> T convert(Class<T> type, Object value) {
+                if (value instanceof Timestamp) {
+                    return (T) value;
+                }
+                if (value instanceof Date) {
+                    return (T) new Timestamp(((Date) value).getTime());
+                }
+                if (value instanceof Long) {
+                    return (T) new Timestamp((Long) value);
+                }
+                if (value instanceof Integer) {
+                    return (T) new Timestamp(((Integer) value).longValue());
+                }
+                if (value instanceof String) {
+                    try {
+                        return (T) Timestamp.valueOf((String) value);
+                    } catch (Exception e) {
+                        try {
+                            return (T) new Timestamp(Long.parseLong((String) value));
+                        } catch (Exception ex) {
+                            return null;
+                        }
+                    }
+                }
+                return null;
+            }
+        }, Timestamp.class);
 
         BeanUtilsBean.getInstance().getConvertUtils().register(new Converter() {
             @Override

--- a/jetlinks-components/common-component/src/test/java/org/jetlinks/community/configuration/CommonConfigurationTest.java
+++ b/jetlinks-components/common-component/src/test/java/org/jetlinks/community/configuration/CommonConfigurationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.configuration;
+
+import org.apache.commons.beanutils.BeanUtilsBean;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CommonConfigurationTest {
+
+    static {
+        try {
+            Class.forName(CommonConfiguration.class.getName());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    void testTimestamp() {
+        long timestamp = 1717200000000L;
+        BeanUtilsBean beanUtils = BeanUtilsBean.getInstance();
+
+        assertEquals(timestamp, ((Timestamp) beanUtils
+            .getConvertUtils()
+            .convert(new Date(timestamp), Timestamp.class)).getTime());
+
+        assertEquals(timestamp, ((Timestamp) beanUtils
+            .getConvertUtils()
+            .convert(timestamp, Timestamp.class)).getTime());
+
+        assertEquals(timestamp, ((Timestamp) beanUtils
+            .getConvertUtils()
+            .convert(String.valueOf(timestamp), Timestamp.class)).getTime());
+
+        assertEquals(Timestamp.valueOf("2026-05-22 10:20:30"), beanUtils
+            .getConvertUtils()
+            .convert("2026-05-22 10:20:30", Timestamp.class));
+    }
+}


### PR DESCRIPTION
### What changed

Add a global BeanUtils converter for `java.sql.Timestamp` in `CommonConfiguration`.

This PR targets the `2.11` branch and is submitted only on GitHub to avoid duplicate PRs across mirrors.

### Why

Some framework mapping and bean-copy scenarios need to convert values from `Date`, numeric timestamps, or strings into `Timestamp`.
Without an explicit converter, these conversions may fail or behave inconsistently.

### Supported inputs

- `Timestamp`
- `Date`
- `Long`
- `Integer`
- `String` formatted as `yyyy-MM-dd HH:mm:ss`
- Numeric timestamp string

### Tests

Added unit coverage in `CommonConfigurationTest` for:

- `Date` to `Timestamp`
- `Long` to `Timestamp`
- numeric timestamp `String` to `Timestamp`
- formatted datetime `String` to `Timestamp`

Local test command:

```powershell
.\mvnw.cmd -pl jetlinks-components\common-component -am -Dtest=CommonConfigurationTest -DfailIfNoTests=false test