### PR TITLE
fix(components): 修复时序聚合 SQL 注入

### DIFF
--- a/jetlinks-components/common-component/src/main/java/org/jetlinks/community/utils/SqlSecurityUtils.java
+++ b/jetlinks-components/common-component/src/main/java/org/jetlinks/community/utils/SqlSecurityUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.utils;
+
+/**
+ * 物数据组件中手写 SQL 片段的最小安全辅助工具。
+ *
+ * 仅处理数据库无法参数化的标识符和必须拼接到 native SQL 的字面量；业务查询值仍应优先使用
+ * Query/Term DSL 或数据库驱动参数绑定。
+ */
+public final class SqlSecurityUtils {
+
+    private SqlSecurityUtils() {
+    }
+
+    public static String aggregationAlias(int index) {
+        return "__agg_" + index;
+    }
+
+    public static String quoteDouble(String identifier) {
+        return quote(identifier, '"');
+    }
+
+    public static String quoteBacktick(String identifier) {
+        return quote(identifier, '`');
+    }
+
+    public static String quoteSingleLiteral(String value) {
+        return quote(value, '\'');
+    }
+
+    private static String quote(String value, char quote) {
+        String text = value == null ? "" : value;
+        String quoted = String.valueOf(quote);
+        return quoted + text.replace(quoted, quoted + quoted) + quoted;
+    }
+}

--- a/jetlinks-components/common-component/src/test/java/org/jetlinks/community/utils/SqlSecurityUtilsTest.java
+++ b/jetlinks-components/common-component/src/test/java/org/jetlinks/community/utils/SqlSecurityUtilsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SqlSecurityUtilsTest {
+
+    @Test
+    void shouldEscapeSqlIdentifierQuotes() {
+        assertEquals("\"a\"\"b\"", SqlSecurityUtils.quoteDouble("a\"b"));
+        assertEquals("`a``b`", SqlSecurityUtils.quoteBacktick("a`b"));
+    }
+
+    @Test
+    void shouldEscapeSingleQuotedLiteral() {
+        assertEquals("'cpu'' or 1=1 --'", SqlSecurityUtils.quoteSingleLiteral("cpu' or 1=1 --"));
+    }
+
+    @Test
+    void shouldGenerateStableInternalAggregationAlias() {
+        assertEquals("__agg_0", SqlSecurityUtils.aggregationAlias(0));
+        assertEquals("__agg_12", SqlSecurityUtils.aggregationAlias(12));
+    }
+}

--- a/jetlinks-components/tdengine-component/src/main/java/org/jetlinks/community/tdengine/things/TDengineColumnModeQueryOperations.java
+++ b/jetlinks-components/tdengine-component/src/main/java/org/jetlinks/community/tdengine/things/TDengineColumnModeQueryOperations.java
@@ -27,6 +27,7 @@ import org.jetlinks.community.things.data.operations.DataSettings;
 import org.jetlinks.community.things.data.operations.MetricBuilder;
 import org.jetlinks.community.timeseries.TimeSeriesData;
 import org.jetlinks.community.timeseries.query.AggregationData;
+import org.jetlinks.community.utils.SqlSecurityUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -35,6 +36,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.function.Function;
@@ -75,11 +77,14 @@ class TDengineColumnModeQueryOperations extends ColumnModeQueryOperationsBase {
         StringJoiner joiner = new StringJoiner("", "select ", "");
         joiner.add("last(`_ts`) _ts");
 
+        // 聚合列只使用服务端别名，请求 property 按 TDengine 标识符规则转义。
+        Map<String, String> aliases = new LinkedHashMap<>();
+        int index = 0;
         for (PropertyAggregation property : context.getProperties()) {
-            joiner.add(",");
-            joiner.add(TDengineThingDataHelper.convertAggFunction(property))
-                  .add("(`").add(property.getProperty()).add("`)")
-                  .add(" `").add(property.getAlias()).add("`");
+            String alias = property.getAlias();
+            String internalAlias = SqlSecurityUtils.aggregationAlias(index++);
+            aliases.put(alias, internalAlias);
+            joiner.add(",").add(createAggregationColumn(property, internalAlias));
         }
 
         joiner
@@ -106,13 +111,22 @@ class TDengineColumnModeQueryOperations extends ColumnModeQueryOperationsBase {
             .map(map -> {
                 TimeSeriesData timeSeriesData = TDengineThingDataHelper.convertToTsData(map);
                 long ts = timeSeriesData.getTimestamp();
-                Map<String, Object> newData = timeSeriesData.getData();
+                Map<String, Object> newData = new LinkedHashMap<>();
                 for (PropertyAggregation property : context.getProperties()) {
-                    newData.putIfAbsent(property.getAlias(), property.getDefaultValue());
+                    String alias = property.getAlias();
+                    newData.put(alias, timeSeriesData
+                        .get(aliases.get(alias))
+                        .orElse(property.getDefaultValue()));
                 }
                 newData.put("time", formatter.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), ZoneId.systemDefault())));
                 return AggregationData.of(newData);
             })
             .take(request.getLimit());
+    }
+
+    static String createAggregationColumn(PropertyAggregation property, String internalAlias) {
+        return TDengineThingDataHelper.convertAggFunction(property)
+            + "(" + SqlSecurityUtils.quoteBacktick(property.getProperty()) + ") "
+            + SqlSecurityUtils.quoteBacktick(internalAlias);
     }
 }

--- a/jetlinks-components/tdengine-component/src/main/java/org/jetlinks/community/tdengine/things/TDengineRowModeQueryOperations.java
+++ b/jetlinks-components/tdengine-component/src/main/java/org/jetlinks/community/tdengine/things/TDengineRowModeQueryOperations.java
@@ -32,6 +32,7 @@ import org.jetlinks.community.things.data.operations.RowModeQueryOperationsBase;
 import org.jetlinks.community.timeseries.TimeSeriesData;
 import org.jetlinks.community.timeseries.query.Aggregation;
 import org.jetlinks.community.timeseries.query.AggregationData;
+import org.jetlinks.community.utils.SqlSecurityUtils;
 import org.jetlinks.reactor.ql.utils.CastUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -90,15 +91,14 @@ class TDengineRowModeQueryOperations extends RowModeQueryOperationsBase {
         StringJoiner agg = new StringJoiner("");
         agg.add("property,last(`_ts`) _ts");
 
+        // SQL 只使用服务端生成的别名，查询后再映射回请求 alias。
+        Map<String, String> aliases = new LinkedHashMap<>();
+        int index = 0;
         for (PropertyAggregation property : properties) {
-            agg.add(",");
-            agg.add(TDengineThingDataHelper.convertAggFunction(property));
-            if(property.getAgg()== Aggregation.COUNT){
-                agg .add("(`value`)");
-            }else {
-                agg .add("(`numberValue`)");
-            }
-            agg.add(" `").add("value_" + property.getAlias()).add("`");
+            String alias = property.getAlias();
+            String internalAlias = SqlSecurityUtils.aggregationAlias(index++);
+            aliases.put(alias, internalAlias);
+            agg.add(",").add(createAggregationColumn(property, internalAlias));
         }
 
         String sql = String.join(
@@ -121,7 +121,8 @@ class TDengineRowModeQueryOperations extends RowModeQueryOperationsBase {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
 
         if (properties.length == 1) {
-            String key = "value_" + properties[0].getAlias();
+            String alias = properties[0].getAlias();
+            String key = aliases.get(alias);
             return helper
                 .query(dataSql)
                 .sort(Comparator.comparing(TimeSeriesData::getTimestamp).reversed())
@@ -130,7 +131,7 @@ class TDengineRowModeQueryOperations extends RowModeQueryOperationsBase {
                     Map<String, Object> newData = new HashMap<>();
                     newData.put("time", formatter.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), ZoneId
                         .systemDefault())));
-                    newData.put(properties[0].getAlias(), timeSeriesData.get(key).orElse(properties[0].getDefaultValue()));
+                    newData.put(alias, timeSeriesData.get(key).orElse(properties[0].getDefaultValue()));
 
                     return AggregationData.of(newData);
                 })
@@ -155,8 +156,9 @@ class TDengineRowModeQueryOperations extends RowModeQueryOperationsBase {
                 .map(map -> {
                     Map<String, Object> newResult = new HashMap<>();
                     for (PropertyAggregation property : properties) {
-                        String key = "value_" + property.getAlias();
-                        newResult.put(property.getAlias(), Optional.ofNullable(map.get(key)).orElse(property.getDefaultValue()));
+                        String alias = property.getAlias();
+                        String key = aliases.get(alias);
+                        newResult.put(alias, Optional.ofNullable(map.get(key)).orElse(property.getDefaultValue()));
                     }
                     newResult.put("time", group.key());
                     newResult.put("_time", map.getOrDefault("_time", new Date()));
@@ -167,5 +169,12 @@ class TDengineRowModeQueryOperations extends RowModeQueryOperationsBase {
                       .reversed())
             .doOnNext(data -> data.values().remove("_time"))
             .take(request.getLimit());
+    }
+
+    static String createAggregationColumn(PropertyAggregation property, String internalAlias) {
+        String valueColumn = property.getAgg() == Aggregation.COUNT ? "value" : "numberValue";
+        return TDengineThingDataHelper.convertAggFunction(property)
+            + "(" + SqlSecurityUtils.quoteBacktick(valueColumn) + ") "
+            + SqlSecurityUtils.quoteBacktick(internalAlias);
     }
 }

--- a/jetlinks-components/tdengine-component/src/main/java/org/jetlinks/community/tdengine/things/TDengineRowModeQueryOperations.java
+++ b/jetlinks-components/tdengine-component/src/main/java/org/jetlinks/community/tdengine/things/TDengineRowModeQueryOperations.java
@@ -25,7 +25,7 @@ import org.jetlinks.core.things.ThingsRegistry;
 import org.jetlinks.community.things.data.AggregationRequest;
 import org.jetlinks.community.things.data.PropertyAggregation;
 import org.jetlinks.community.things.data.ThingPropertyDetail;
-import org.jetlinks.community.things.data.ThingsDataConstants;
+import org.jetlinks.community.things.data.ThingsDataUtils;
 import org.jetlinks.community.things.data.operations.DataSettings;
 import org.jetlinks.community.things.data.operations.MetricBuilder;
 import org.jetlinks.community.things.data.operations.RowModeQueryOperationsBase;
@@ -33,7 +33,6 @@ import org.jetlinks.community.timeseries.TimeSeriesData;
 import org.jetlinks.community.timeseries.query.Aggregation;
 import org.jetlinks.community.timeseries.query.AggregationData;
 import org.jetlinks.community.utils.SqlSecurityUtils;
-import org.jetlinks.reactor.ql.utils.CastUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -44,6 +43,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 class TDengineRowModeQueryOperations extends RowModeQueryOperationsBase {
 
@@ -138,36 +138,32 @@ class TDengineRowModeQueryOperations extends RowModeQueryOperationsBase {
                 .take(request.getLimit())
                 ;
         }
+        NavigableMap<Long, Map<String, Object>> prepares =
+            ThingsDataUtils.prepareAggregationData(request, properties);
+        Map<String, List<PropertyAggregation>> propertyAgg = Arrays
+            .stream(properties)
+            .collect(Collectors.groupingBy(PropertyAggregation::getProperty));
         return helper
             .query(dataSql)
-            .map(timeSeriesData -> {
-                long ts = timeSeriesData.getTimestamp();
-                Map<String, Object> newData = timeSeriesData.getData();
-                newData.put("time", formatter.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), ZoneId.systemDefault())));
-                newData.put("_time", ts);
-                return newData;
-            })
-            .groupBy(data -> (String) data.get("time"), Integer.MAX_VALUE)
-            .flatMap(group -> group
-                .reduceWith(HashMap::new, (a, b) -> {
-                    a.putAll(b);
-                    return a;
-                })
-                .map(map -> {
-                    Map<String, Object> newResult = new HashMap<>();
-                    for (PropertyAggregation property : properties) {
-                        String alias = property.getAlias();
-                        String key = aliases.get(alias);
-                        newResult.put(alias, Optional.ofNullable(map.get(key)).orElse(property.getDefaultValue()));
+            .doOnNext(data -> {
+                long timestamp = data.getTimestamp();
+                Map<String, Object> prepare = ThingsDataUtils.findAggregationData(timestamp, prepares);
+                if (prepare != null) {
+                    Object propertyValue = data.getData().get("property");
+                    List<PropertyAggregation> proAggs = propertyValue == null
+                        ? null
+                        : propertyAgg.get(propertyValue.toString());
+                    // 每个 partition 行都会计算全部投影，只消费当前 property 对应的聚合列。
+                    if (proAggs != null) {
+                        for (PropertyAggregation proAgg : proAggs) {
+                            String alias = proAgg.getAlias();
+                            prepare.put(alias, data.get(aliases.get(alias)).orElse(proAgg.getDefaultValue()));
+                        }
                     }
-                    newResult.put("time", group.key());
-                    newResult.put("_time", map.getOrDefault("_time", new Date()));
-                    return AggregationData.of(newResult);
-                }))
-            .sort(Comparator
-                      .<AggregationData, Date>comparing(data -> CastUtils.castDate(data.values().get("_time")))
-                      .reversed())
-            .doOnNext(data -> data.values().remove("_time"))
+                }
+            })
+            .thenMany(Flux.fromIterable(prepares.descendingMap().values()))
+            .map(AggregationData::of)
             .take(request.getLimit());
     }
 

--- a/jetlinks-components/tdengine-component/src/test/java/org/jetlinks/community/tdengine/things/TDengineSqlSecurityTest.java
+++ b/jetlinks-components/tdengine-component/src/test/java/org/jetlinks/community/tdengine/things/TDengineSqlSecurityTest.java
@@ -15,12 +15,25 @@
  */
 package org.jetlinks.community.tdengine.things;
 
+import org.jetlinks.core.things.ThingMetadata;
+import org.jetlinks.community.things.data.AggregationRequest;
 import org.jetlinks.community.things.data.PropertyAggregation;
+import org.jetlinks.community.things.data.operations.DataSettings;
+import org.jetlinks.community.things.data.operations.MetricBuilder;
+import org.jetlinks.community.timeseries.TimeSeriesData;
 import org.jetlinks.community.timeseries.query.Aggregation;
+import org.jetlinks.community.timeseries.query.AggregationData;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class TDengineSqlSecurityTest {
 
@@ -63,5 +76,69 @@ class TDengineSqlSecurityTest {
 
         assertEquals("max(`temperature``), current_user --`) `__agg_1`", sql);
         assertFalse(sql.contains(aggregation.getAlias()));
+    }
+
+    @Test
+    void shouldMapAggregationAliasByPropertyPartition() {
+        PropertyAggregation temperatureAvg = new PropertyAggregation(
+            "temperature", "temperatureAvg", Aggregation.AVG);
+        PropertyAggregation humidityMax = new PropertyAggregation(
+            "humidity", "humidityMax", Aggregation.MAX);
+        PropertyAggregation temperatureCount = new PropertyAggregation(
+            "temperature", "temperatureCount", Aggregation.COUNT);
+
+        TDengineThingDataHelper helper = mock(TDengineThingDataHelper.class);
+        when(helper.query(anyString())).thenReturn(Flux.just(
+            TimeSeriesData.of(0, Map.of(
+                "property", "temperature",
+                "__agg_0", 20D,
+                "__agg_1", 20D,
+                "__agg_2", 2L
+            )),
+            TimeSeriesData.of(0, Map.of(
+                "property", "humidity",
+                "__agg_0", 80D,
+                "__agg_1", 80D,
+                "__agg_2", 3L
+            ))
+        ));
+
+        AggregationRequest request = AggregationRequest
+            .builder()
+            .interval(null)
+            .limit(1)
+            .build();
+
+        List<AggregationData> result = new TestOperations(helper)
+            .aggregate(request, temperatureAvg, humidityMax, temperatureCount)
+            .collectList()
+            .block();
+
+        assertEquals(1, result.size(), String.valueOf(result));
+        assertEquals(
+            Map.of(
+                "temperatureAvg", 20D,
+                "humidityMax", 80D,
+                "temperatureCount", 2L
+            ),
+            result.get(0).asMap()
+        );
+    }
+
+    private static class TestOperations extends TDengineRowModeQueryOperations {
+
+        TestOperations(TDengineThingDataHelper helper) {
+            super("device", "product", null,
+                  MetricBuilder.DEFAULT, new DataSettings(), null, helper);
+        }
+
+        Flux<AggregationData> aggregate(AggregationRequest request,
+                                        PropertyAggregation... properties) {
+            return doAggregation(
+                "device_properties_product",
+                request,
+                new AggregationContext(mock(ThingMetadata.class), properties)
+            );
+        }
     }
 }

--- a/jetlinks-components/tdengine-component/src/test/java/org/jetlinks/community/tdengine/things/TDengineSqlSecurityTest.java
+++ b/jetlinks-components/tdengine-component/src/test/java/org/jetlinks/community/tdengine/things/TDengineSqlSecurityTest.java
@@ -87,15 +87,16 @@ class TDengineSqlSecurityTest {
         PropertyAggregation temperatureCount = new PropertyAggregation(
             "temperature", "temperatureCount", Aggregation.COUNT);
 
+        long timestamp = 1_725_000_000_000L;
         TDengineThingDataHelper helper = mock(TDengineThingDataHelper.class);
         when(helper.query(anyString())).thenReturn(Flux.just(
-            TimeSeriesData.of(0, Map.of(
+            TimeSeriesData.of(timestamp, Map.of(
                 "property", "temperature",
                 "__agg_0", 20D,
                 "__agg_1", 20D,
                 "__agg_2", 2L
             )),
-            TimeSeriesData.of(0, Map.of(
+            TimeSeriesData.of(timestamp, Map.of(
                 "property", "humidity",
                 "__agg_0", 80D,
                 "__agg_1", 80D,

--- a/jetlinks-components/tdengine-component/src/test/java/org/jetlinks/community/tdengine/things/TDengineSqlSecurityTest.java
+++ b/jetlinks-components/tdengine-component/src/test/java/org/jetlinks/community/tdengine/things/TDengineSqlSecurityTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.tdengine.things;
+
+import org.jetlinks.community.things.data.PropertyAggregation;
+import org.jetlinks.community.timeseries.query.Aggregation;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class TDengineSqlSecurityTest {
+
+    @Test
+    void shouldUseInternalAliasInRowMode() {
+        PropertyAggregation aggregation = new PropertyAggregation(
+            "temperature",
+            "probe`, current_user as `db_user",
+            Aggregation.AVG
+        );
+
+        String sql = TDengineRowModeQueryOperations.createAggregationColumn(aggregation, "__agg_0");
+
+        assertEquals("avg(`numberValue`) `__agg_0`", sql);
+        assertFalse(sql.contains(aggregation.getAlias()));
+    }
+
+    @Test
+    void shouldKeepCountValueColumnInRowMode() {
+        PropertyAggregation aggregation = new PropertyAggregation(
+            "temperature",
+            "count",
+            Aggregation.COUNT
+        );
+
+        String sql = TDengineRowModeQueryOperations.createAggregationColumn(aggregation, "__agg_0");
+
+        assertEquals("count(`value`) `__agg_0`", sql);
+    }
+
+    @Test
+    void shouldEscapePropertyAndUseInternalAliasInColumnMode() {
+        PropertyAggregation aggregation = new PropertyAggregation(
+            "temperature`), current_user --",
+            "probe`, current_user as `db_user",
+            Aggregation.MAX
+        );
+
+        String sql = TDengineColumnModeQueryOperations.createAggregationColumn(aggregation, "__agg_1");
+
+        assertEquals("max(`temperature``), current_user --`) `__agg_1`", sql);
+        assertFalse(sql.contains(aggregation.getAlias()));
+    }
+}

--- a/jetlinks-components/things-component/src/main/java/org/jetlinks/community/things/data/ThingsDataUtils.java
+++ b/jetlinks-components/things-component/src/main/java/org/jetlinks/community/things/data/ThingsDataUtils.java
@@ -15,7 +15,6 @@
  */
 package org.jetlinks.community.things.data;
 
-import org.jetlinks.community.timeseries.utils.TimeSeriesUtils;
 import org.jetlinks.community.Interval;
 import org.jetlinks.community.timeseries.utils.TimeSeriesUtils;
 import org.joda.time.DateTime;
@@ -52,13 +51,13 @@ public class ThingsDataUtils {
     public static NavigableMap<Long, Map<String, Object>> prepareAggregationData(AggregationRequest request,
                                                                                  BiFunction<Long, Interval, Long> timeTruncate,
                                                                                  PropertyAggregation... properties) {
-        NavigableMap<Long, Map<String, Object>> data = new TreeMap<>(Comparator.comparingLong(l -> -l));
+        NavigableMap<Long, Map<String, Object>> data = new TreeMap<>();
         Map<String, Object> valueMap = new HashMap<>();
         for (PropertyAggregation property : properties) {
             valueMap.put(property.getAlias(), property.getDefaultValue());
         }
         if (request.getInterval() == null) {
-            data.put(0L,valueMap);
+            data.put(0L, valueMap);
             return data;
         }
         DateTimeFormatter formatter = DateTimeFormat.forPattern(request.getFormat());

--- a/jetlinks-components/things-component/src/test/java/org/jetlinks/community/things/data/ThingsDataUtilsTest.java
+++ b/jetlinks-components/things-component/src/test/java/org/jetlinks/community/things/data/ThingsDataUtilsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.things.data;
+
+import org.jetlinks.community.Interval;
+import org.jetlinks.community.timeseries.query.Aggregation;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.NavigableMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ThingsDataUtilsTest {
+
+    private static final PropertyAggregation TEMPERATURE =
+        new PropertyAggregation("temperature", "temperatureAvg", Aggregation.AVG);
+
+    @Test
+    void shouldMatchNonZeroTimestampWithoutInterval() {
+        AggregationRequest request = AggregationRequest
+            .builder()
+            .interval(null)
+            .build();
+
+        NavigableMap<Long, Map<String, Object>> prepares =
+            ThingsDataUtils.prepareAggregationData(request, TEMPERATURE);
+
+        assertEquals(0L, prepares.firstKey());
+        assertSame(prepares.get(0L), ThingsDataUtils.findAggregationData(1_725_000_000_000L, prepares));
+    }
+
+    @Test
+    void shouldMatchRawTimestampToPreviousTimeBucket() {
+        long from = 1_725_000_000_000L;
+        AggregationRequest request = AggregationRequest
+            .builder()
+            .interval(Interval.ofHours(1))
+            .format("yyyy-MM-dd HH:mm")
+            .from(new Date(from))
+            .to(new Date(from + 2 * 60 * 60 * 1000L))
+            .build();
+
+        NavigableMap<Long, Map<String, Object>> prepares =
+            ThingsDataUtils.prepareAggregationData(request, (time, interval) -> time, TEMPERATURE);
+
+        long firstBucket = prepares.firstKey();
+        assertSame(
+            prepares.get(firstBucket),
+            ThingsDataUtils.findAggregationData(firstBucket + 30 * 60 * 1000L, prepares)
+        );
+    }
+
+    @Test
+    void shouldPrepareNaturalOrderAndReadNewestFirst() {
+        long from = 1_725_000_000_000L;
+        AggregationRequest request = AggregationRequest
+            .builder()
+            .interval(Interval.ofHours(1))
+            .format("yyyy-MM-dd HH:mm")
+            .from(new Date(from))
+            .to(new Date(from + 2 * 60 * 60 * 1000L))
+            .build();
+
+        NavigableMap<Long, Map<String, Object>> prepares =
+            ThingsDataUtils.prepareAggregationData(request, (time, interval) -> time, TEMPERATURE);
+
+        assertEquals(prepares.lastKey(), prepares.descendingMap().firstKey());
+    }
+}

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBColumnModeQueryOperations.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBColumnModeQueryOperations.java
@@ -41,6 +41,7 @@ import org.jetlinks.community.timescaledb.TimescaleDBUtils;
 import org.jetlinks.community.timeseries.TimeSeriesData;
 import org.jetlinks.community.timeseries.query.Aggregation;
 import org.jetlinks.community.timeseries.query.AggregationData;
+import org.jetlinks.community.utils.SqlSecurityUtils;
 import org.jetlinks.reactor.ql.utils.CastUtils;
 import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
@@ -132,10 +133,16 @@ public class TimescaleDBColumnModeQueryOperations extends ColumnModeQueryOperati
             column.setAlias(timestampAlias);
         }
 
+        // SQL 只使用服务端生成的别名，查询后再映射回请求 alias。
+        Map<String, String> aliases = new LinkedHashMap<>();
+        int index = 0;
         for (PropertyAggregation property : context.getProperties()) {
+            String alias = property.getAlias();
+            String internalAlias = SqlSecurityUtils.aggregationAlias(index++);
+            aliases.put(alias, internalAlias);
             SelectColumn column = new SelectColumn();
             column.setColumn(property.getProperty());
-            column.setAlias(property.getAlias());
+            column.setAlias(internalAlias);
             TimescaleDBUtils.applyAggColumn(property.getAgg(), column);
 
             query.select(column);
@@ -165,7 +172,7 @@ public class TimescaleDBColumnModeQueryOperations extends ColumnModeQueryOperati
                     .doOnNext(data -> {
                         for (PropertyAggregation property : context.getProperties()) {
                             String alias = property.getAlias();
-                            data.get(alias)
+                            data.get(aliases.get(alias))
                                 .ifPresent(val -> prepare.put(alias, val));
                         }
                     });

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBColumnModeQueryOperations.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBColumnModeQueryOperations.java
@@ -177,7 +177,7 @@ public class TimescaleDBColumnModeQueryOperations extends ColumnModeQueryOperati
                         }
                     });
             })
-            .thenMany(Flux.fromIterable(prepares.values()))
+            .thenMany(Flux.fromIterable(prepares.descendingMap().values()))
             .map(AggregationData::of)
             .take((long) request.getLimit() * context.getProperties().length)
             .contextWrite(ctx -> ctx.put(Logger.class, log));

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBRowModeQueryOperations.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBRowModeQueryOperations.java
@@ -191,7 +191,7 @@ public class TimescaleDBRowModeQueryOperations extends RowModeQueryOperationsBas
                         }
                     });
             })
-            .thenMany(Flux.fromIterable(prepares.values()))
+            .thenMany(Flux.fromIterable(prepares.descendingMap().values()))
             .map(AggregationData::of)
             .take((long) request.getLimit() * propertyId.size())
             .contextWrite(ctx -> ctx.put(Logger.class, log));

--- a/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBRowModeQueryOperations.java
+++ b/jetlinks-components/timescaledb-component/src/main/java/org/jetlinks/community/timescaledb/thing/TimescaleDBRowModeQueryOperations.java
@@ -41,6 +41,7 @@ import org.jetlinks.community.timescaledb.TimescaleDBUtils;
 import org.jetlinks.community.timeseries.TimeSeriesData;
 import org.jetlinks.community.timeseries.query.Aggregation;
 import org.jetlinks.community.timeseries.query.AggregationData;
+import org.jetlinks.community.utils.SqlSecurityUtils;
 import org.jetlinks.reactor.ql.utils.CastUtils;
 import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
@@ -130,19 +131,28 @@ public class TimescaleDBRowModeQueryOperations extends RowModeQueryOperationsBas
         query.select(propertyColumn);
 
         Set<String> propertyId = new HashSet<>();
+        // SQL 只使用服务端生成的别名，查询后再映射回请求 alias。
+        Map<String, String> aliases = new LinkedHashMap<>();
 
         if (context.getProperties().length > 1) {
+            int index = 0;
             for (PropertyAggregation property : context.getProperties()) {
+                String alias = property.getAlias();
+                String internalAlias = SqlSecurityUtils.aggregationAlias(index++);
+                aliases.put(alias, internalAlias);
                 NativeSelectColumn column = new NativeSelectColumn(
                     "case when property = ? then " + createAggFunction(property.getAgg()) +
-                        " end as \"" + property.getAlias() + "\"");
+                        " end as " + SqlSecurityUtils.quoteDouble(internalAlias));
                 column.setParameters(new Object[]{property.getProperty()});
                 query.select(column);
                 propertyId.add(property.getProperty());
             }
         } else {
             PropertyAggregation property = context.getProperties()[0];
-            String sql = createAggFunction(property.getAgg()) + " as \"" + property.getAlias() + "\"";
+            String alias = property.getAlias();
+            String internalAlias = SqlSecurityUtils.aggregationAlias(0);
+            aliases.put(alias, internalAlias);
+            String sql = createAggFunction(property.getAgg()) + " as " + SqlSecurityUtils.quoteDouble(internalAlias);
             query.select(NativeSelectColumn.of(sql));
             propertyId.add(property.getProperty());
 
@@ -176,7 +186,7 @@ public class TimescaleDBRowModeQueryOperations extends RowModeQueryOperationsBas
                     .doOnNext(data -> {
                         for (PropertyAggregation property : context.getProperties()) {
                             String alias = property.getAlias();
-                            data.get(alias)
+                            data.get(aliases.get(alias))
                                 .ifPresent(val -> prepare.put(alias, val));
                         }
                     });


### PR DESCRIPTION
## 目的

- 修复设备属性聚合请求中的外部 alias 被拼接为 TimescaleDB 与 TDengine SELECT 标识符导致的 SQL 注入风险
- 修复 TDengine 列模式 property 直接拼接到 SQL 标识符的同源风险
- 修复 TDengine 行模式 `partition by property` 多属性聚合结果相互覆盖
- 修复聚合预填充时间桶倒序比较器导致的原始时间戳匹配失败，并统一 TimescaleDB / TDengine 最新时间优先输出
- 保持聚合接口原有 alias 返回契约
- Closes #764

## 核心变动

- common-component：新增 SqlSecurityUtils，统一生成内部聚合别名并提供 SQL 标识符、字面量转义能力
- timescaledb-component：行模式与列模式聚合使用服务端生成的 __agg_n 别名，查询后再映射回请求 alias
- tdengine-component：行模式与列模式聚合改用内部别名；列模式 property 使用 TDengine 反引号标识符转义；行模式根据返回的 property 只消费对应聚合列，支持同一属性配置多个 alias/聚合函数
- 原模块修复：已先在 jetlinks-v2/jetlinks-components#1548 增加失败回归用例并修复，再同步到 community

## 设计与测试目标

- 设计稿：不适用；本次为范围明确的同源缺陷修复，TimescaleDB 按 jetlinks-components#1528 对应改动机械迁移，TDengine 按相同安全边界补齐
- 用户确认：已明确要求同时修复 TimescaleDB 与 TDengine，并要求先在原模块复现、修复后同步 community
- 注释 / 公共契约：内部别名与 property 分区映射处已说明安全/正确性边界；不涉及 SPI
- 数据权限：不适用；未修改 Controller、认证或 AssetsHolder 权限链路
- 数据库兼容与性能：适用于 TimescaleDB/PostgreSQL 与 TDengine 标识符方言；未改变查询条件、索引、分页或并发模型
- 链路追踪：不适用；未新增业务阶段、外部调用或异步边界
- MBean 运维可观测性：不适用；未新增常驻任务、缓存、队列或后台执行器

## 测试结果

- 原模块：`TDengineAggregationSecurityTest` 先在未修复实现复现失败（多属性结果为空/错位），修复后改用真实非零时间戳，4 passed
- community：`ThingsDataUtilsTest` 3 passed，覆盖 interval=null 非零时间戳、原始时间戳匹配前一时间桶、自然顺序预填充与最新优先读取
- community：`TDengineSqlSecurityTest` 4 passed，真实非零时间戳下覆盖多属性与同属性多聚合的 partition 映射
- 既有安全测试：`SqlSecurityUtilsTest` 3 passed；TDengine alias/property/COUNT SQL 构造用例通过
- 编译验证：原模块 TDengine 测试通过；community 的 tdengine-component 与 timescaledb-component 依赖 reactor 均编译成功
- 集成测试：未执行；当前环境未配置真实 TimescaleDB 与 TDengine 实例，该限制已在风险说明中保留
- 压力测试：不适用；未改变查询结构、索引、分页、批次或并发模型

## 文档同步情况

- 无需更新长期文档；修复依据和验证证据记录在本 PR 及 jetlinks-v2/jetlinks-components#1548

## 风险与说明

- 影响范围：common-component SQL 安全工具，以及 TimescaleDB、TDengine 物数据行/列模式聚合
- 未覆盖场景：尚未连接真实 TimescaleDB 与 TDengine 重放恶意 alias/property POC
- 已知限制：本次限定设备物数据聚合链路，不扩展处理其他由服务端内部构造的时序统计查询
