### PR TITLE
fix(系统配置): 修复 base-path 环回地址绕过

### DIFF
--- a/jetlinks-components/common-component/src/main/java/org/jetlinks/community/config/verification/ConfigVerificationService.java
+++ b/jetlinks-components/common-component/src/main/java/org/jetlinks/community/config/verification/ConfigVerificationService.java
@@ -27,8 +27,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.net.URI;
+import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.Objects;
@@ -74,37 +76,53 @@ public class ConfigVerificationService {
             return Mono.empty();
         }
 
-        URI uri = URI.create(CastUtils.castString(CastUtils.castString(basePath).concat(PATH_VERIFICATION_URI)));
-        if (Objects.equals(uri.getHost(), "127.0.0.1")){
-            return Mono.error(new BusinessException("error.base_path_host_error", 500, "127.0.0.1"));
-        }
-        if (Objects.equals(uri.getHost(), "localhost")){
-            return Mono.error(new BusinessException("error.base_path_host_error", 500, "localhost"));
-        }
+        URI uri = URI.create(CastUtils.castString(basePath).concat(PATH_VERIFICATION_URI));
 
-        return webClient
-            .get()
-            .uri(uri)
-            .exchangeToMono(cr -> {
-                if (cr.statusCode().is2xxSuccessful()) {
-                    return cr.bodyToMono(String.class)
-                             .filter(r-> r.contains("auth:"+PATH_VERIFICATION_URI))
-                             .switchIfEmpty(Mono.error(()-> new BusinessException("error.base_path_error")));
-                }
-                return Mono.defer(() -> Mono.error(new BusinessException("error.base_path_error")));
-            })
-            .timeout(Duration.ofSeconds(3), Mono.error(TimeoutException::new))
-            .onErrorResume(err -> {
-                while (err != null) {
-                    if (err instanceof TimeoutException) {
-                        return Mono.error(() -> new BusinessException("error.base_path_validate_request_timeout"));
-                    } else if (err instanceof UnknownHostException) {
-                        return Mono.error(() -> new BusinessException("error.base_path_DNS_resolution_failed"));
+        return validateHost(uri)
+            .then(
+                webClient
+                    .get()
+                    .uri(uri)
+                    .exchangeToMono(cr -> {
+                        if (cr.statusCode().is2xxSuccessful()) {
+                            return cr.bodyToMono(String.class)
+                                     .filter(r -> r.contains("auth:" + PATH_VERIFICATION_URI))
+                                     .switchIfEmpty(Mono.error(() -> new BusinessException("error.base_path_error")));
+                        }
+                        return Mono.defer(() -> Mono.error(new BusinessException("error.base_path_error")));
+                    })
+                    .timeout(Duration.ofSeconds(3), Mono.error(TimeoutException::new))
+                    .onErrorResume(err -> {
+                        while (err != null) {
+                            if (err instanceof TimeoutException) {
+                                return Mono.error(() -> new BusinessException("error.base_path_validate_request_timeout"));
+                            } else if (err instanceof UnknownHostException) {
+                                return Mono.error(() -> new BusinessException("error.base_path_DNS_resolution_failed"));
+                            }
+                            err = err.getCause();
+                        }
+                        return Mono.error(() -> new BusinessException("error.base_path_error"));
+                    })
+                    .then()
+            );
+    }
+
+    private Mono<Void> validateHost(URI uri) {
+        String host = uri.getHost();
+        if (host == null) {
+            return Mono.error(new BusinessException("error.base_path_host_error", 500, "unknown"));
+        }
+        return Mono
+            .fromCallable(() -> InetAddress.getAllByName(host))
+            .subscribeOn(Schedulers.boundedElastic())
+            .flatMap(addresses -> {
+                for (InetAddress address : addresses) {
+                    // base-path 本身可以指向内网服务，但不能回连当前主机的环回接口。
+                    if (address.isLoopbackAddress()) {
+                        return Mono.error(new BusinessException("error.base_path_host_error", 500, host));
                     }
-                    err = err.getCause();
                 }
-                return Mono.error(() -> new BusinessException("error.base_path_error"));
-            })
-            .then();
+                return Mono.empty();
+            });
     }
 }

--- a/jetlinks-components/common-component/src/test/java/org/jetlinks/community/config/verification/ConfigVerificationServiceTest.java
+++ b/jetlinks-components/common-component/src/test/java/org/jetlinks/community/config/verification/ConfigVerificationServiceTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.config.verification;
+
+import org.hswebframework.web.exception.BusinessException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.test.StepVerifier;
+
+class ConfigVerificationServiceTest {
+
+    private final ConfigVerificationService service = new ConfigVerificationService();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "http://127.0.0.1:28081",
+        "http://localhost:28081",
+        "http://localhost.:28081",
+        "http://[::1]:28081"
+    })
+    void shouldRejectLoopbackBasePath(String basePath) {
+        StepVerifier
+            .create(service.doBasePathValidate(basePath))
+            .expectError(BusinessException.class)
+            .verify();
+    }
+}


### PR DESCRIPTION
## 目的

- 修复系统 base-path 校验可通过域名变体或 DNS 解析结果访问环回地址的问题
- 在保留普通内网部署地址能力的同时，阻止对本机环回服务的访问

## 核心变动

- common-component：统一解析 base-path 目标主机，拒绝任一解析结果为 loopback 的地址
- common-component：覆盖 localhost 尾点形式、IPv4、IPv6 及 DNS 解析到环回地址的回归测试

## 设计与测试目标

- 设计稿：不适用；本次为边界明确的小范围安全修复
- 用户确认：已确认，按独立 Issue 提交评审
- 测试目标：覆盖普通内网地址正常路径，以及 localhost 变体、IPv4、IPv6 和 DNS 环回解析等异常与回归路径
- 注释 / 公共契约：不适用；未新增公共 API 或 SPI，校验边界由方法命名及测试表达
- 数据权限：不适用；未涉及资产数据访问
- 数据库兼容与性能：不适用；未涉及 SQL 或持久化
- 链路追踪：不适用；仅调整配置保存前校验，不新增业务链路
- MBean 运维可观测性：不适用；未新增常驻任务、缓存、队列或后台执行器

## 测试结果

- 命令：`mvn -pl jetlinks-components/common-component -am -Dtest=ConfigVerificationServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- 新增/更新测试：`ConfigVerificationServiceTest` 覆盖普通内网 base-path、localhost 尾点形式、IPv4/IPv6 环回地址与 DNS 环回解析
- 单元测试：4 passed, 0 failed, 0 skipped
- 集成测试：不适用；未涉及数据库、消息、事件、协议、跨模块边界或启动装配
- 压力测试：不适用；不涉及批处理、SQL 或高并发数据路径
- 覆盖率：changed class line 24/45（53.3%），branch 4/16（25.0%）

## 文档同步情况

- 已同步：无需同步长期文档；安全校验行为由代码与回归测试维护
- 未同步：无
- 说明：README 长期总览未发生变化；测试证据仅记录在 PR / CI

## 风险与说明

- 影响范围：系统 base-path 保存前校验
- 注释 / 公共契约：不涉及公共契约变更
- 链路追踪 / 可观测性：不涉及
- MBean / 运维可观测性：不涉及
- 未覆盖场景：未进行真实 DNS 服务集成测试，解析分支已通过单元测试验证
- 已知限制：仅禁止环回地址，普通私网地址仍允许用于私有化部署

Closes #765