### PR TITLE
fix(通知管理): 禁止远程邮件附件地址

### DIFF
--- a/jetlinks-components/notify-component/notify-email/src/main/java/org/jetlinks/community/notify/email/embedded/DefaultEmailNotifier.java
+++ b/jetlinks-components/notify-component/notify-email/src/main/java/org/jetlinks/community/notify/email/embedded/DefaultEmailNotifier.java
@@ -15,8 +15,6 @@
  */
 package org.jetlinks.community.notify.email.embedded;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeUtility;
 import lombok.Getter;
@@ -26,22 +24,22 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.hswebframework.web.bean.FastBeanCopier;
 import org.hswebframework.web.exception.BusinessException;
+import org.hswebframework.web.exception.ValidationException;
 import org.hswebframework.web.id.IDGenerator;
 import org.hswebframework.web.validator.ValidatorUtils;
-import org.jetlinks.community.notify.AbstractNotifier;
-import org.jetlinks.core.Values;
 import org.jetlinks.community.io.file.FileManager;
+import org.jetlinks.community.io.utils.FileUtils;
+import org.jetlinks.community.notify.AbstractNotifier;
 import org.jetlinks.community.notify.*;
 import org.jetlinks.community.notify.email.EmailProvider;
 import org.jetlinks.community.notify.template.TemplateManager;
-import org.jetlinks.sdk.server.utils.ConverterUtils;
+import org.jetlinks.core.Values;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.InputStreamSource;
-import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.MediaType;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
@@ -55,6 +53,9 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -207,32 +208,37 @@ public class DefaultEmailNotifier extends AbstractNotifier<EmailTemplate> {
 
 
     protected Mono<? extends InputStreamSource> convertResource(String resource) {
-        if (resource.startsWith("http")) {
-            // 邮件模板属于发送时输入，远程地址不能触发服务端主动下载。
-            return Mono.error(() -> new UnsupportedOperationException("不支持远程附件地址:" + resource));
-        } else if (resource.startsWith("data:") && resource.contains(";base64,")) {
+        if (resource.startsWith("data:") && resource.contains(";base64,")) {
             String base64 = resource.substring(resource.indexOf(";base64,") + 8);
             return Mono.just(
                 new ByteArrayResource(Base64.decodeBase64(base64))
             );
-        } else if (enableFileSystemAttachment && resource.contains("/")) {
-            return Mono.just(
-                new FileSystemResource(resource)
-            );
-        } else {
-            return fileManager
-                .read(resource)
-                .as(DataBufferUtils::join)
-                .map(dataBuffer -> {
-                    try {
-                        ByteBuf buf = ConverterUtils.convertNettyBuffer(dataBuffer);
-                        return new ByteArrayResource(ByteBufUtil.getBytes(buf));
-                    } finally {
-                        DataBufferUtils.release(dataBuffer);
+        }
+        return Mono
+            .defer(() -> {
+                try {
+                    FileUtils.resolveManagedFileId(resource);
+                } catch (ValidationException error) {
+                    if (enableFileSystemAttachment
+                        && !resource.startsWith("http")
+                        && resource.contains("/")) {
+                        return Mono.just(new FileSystemResource(resource));
                     }
-                })
-                .onErrorMap(error -> new UnsupportedOperationException("不支持的文件地址:" + resource, error))
-                .switchIfEmpty(Mono.error(() -> new UnsupportedOperationException("不支持的文件地址:" + resource)));
+                    return Mono.error(error);
+                }
+                return FileUtils
+                    .readManagedInputStream(fileManager, resource)
+                    .map(DefaultEmailNotifier::readAttachment);
+            })
+            .onErrorMap(error -> new UnsupportedOperationException("不支持的文件地址:" + resource, error))
+            .switchIfEmpty(Mono.error(() -> new UnsupportedOperationException("不支持的文件地址:" + resource)));
+    }
+
+    private static ByteArrayResource readAttachment(InputStream stream) {
+        try (stream) {
+            return new ByteArrayResource(stream.readAllBytes());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/jetlinks-components/notify-component/notify-email/src/main/java/org/jetlinks/community/notify/email/embedded/DefaultEmailNotifier.java
+++ b/jetlinks-components/notify-component/notify-email/src/main/java/org/jetlinks/community/notify/email/embedded/DefaultEmailNotifier.java
@@ -41,7 +41,6 @@ import org.jsoup.nodes.Element;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.InputStreamSource;
-import org.springframework.core.io.Resource;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.MediaType;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -96,8 +95,6 @@ public class DefaultEmailNotifier extends AbstractNotifier<EmailTemplate> {
 
     private final FileManager fileManager;
 
-    private final WebClient webClient;
-
     public DefaultEmailNotifier(NotifierProperties properties,
                                 TemplateManager templateManager,
                                 FileManager fileManager,
@@ -128,7 +125,6 @@ public class DefaultEmailNotifier extends AbstractNotifier<EmailTemplate> {
         this.username = properties.getUsername();
         this.javaMailSender = mailSender;
         this.fileManager = fileManager;
-        this.webClient = builder.build();
     }
 
     @Nonnull
@@ -212,11 +208,8 @@ public class DefaultEmailNotifier extends AbstractNotifier<EmailTemplate> {
 
     protected Mono<? extends InputStreamSource> convertResource(String resource) {
         if (resource.startsWith("http")) {
-            return webClient
-                .get()
-                .uri(resource)
-                .accept(MediaType.APPLICATION_OCTET_STREAM)
-                .exchangeToMono(res -> res.bodyToMono(Resource.class));
+            // 邮件模板属于发送时输入，远程地址不能触发服务端主动下载。
+            return Mono.error(() -> new UnsupportedOperationException("不支持远程附件地址:" + resource));
         } else if (resource.startsWith("data:") && resource.contains(";base64,")) {
             String base64 = resource.substring(resource.indexOf(";base64,") + 8);
             return Mono.just(

--- a/jetlinks-components/notify-component/notify-email/src/test/java/org/jetlinks/community/notify/email/embedded/DefaultEmailNotifierTest.java
+++ b/jetlinks-components/notify-component/notify-email/src/test/java/org/jetlinks/community/notify/email/embedded/DefaultEmailNotifierTest.java
@@ -18,31 +18,112 @@ package org.jetlinks.community.notify.email.embedded;
 import org.jetlinks.community.io.file.FileManager;
 import org.jetlinks.community.notify.template.TemplateManager;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.InputStreamSource;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class DefaultEmailNotifierTest {
 
     @Test
     void shouldRejectRemoteAttachment() {
-        DefaultEmailProperties properties = new DefaultEmailProperties();
-        properties.setHost("localhost");
-        properties.setPort(25);
-        properties.setSender("test@example.com");
-
-        DefaultEmailNotifier notifier = new DefaultEmailNotifier(
-            "test",
-            properties,
-            mock(TemplateManager.class),
-            mock(FileManager.class),
-            WebClient.builder()
-        );
+        FileManager fileManager = mock(FileManager.class);
+        DefaultEmailNotifier notifier = createNotifier(fileManager);
 
         StepVerifier
             .create(notifier.convertResource("http://127.0.0.1/internal"))
             .expectError(UnsupportedOperationException.class)
             .verify();
+
+        verifyNoInteractions(fileManager);
+    }
+
+    @Test
+    void shouldReadManagedAttachmentUrl() {
+        byte[] content = "managed-attachment".getBytes(StandardCharsets.UTF_8);
+        FileManager fileManager = mock(FileManager.class);
+        when(fileManager.read("file-id"))
+            .thenReturn(Flux.just(DefaultDataBufferFactory.sharedInstance.wrap(content)));
+
+        DefaultEmailNotifier notifier = createNotifier(fileManager);
+
+        StepVerifier
+            .create(notifier
+                        .convertResource("http://localhost:8848/api/file/file-id.txt?accessKey=test")
+                        .map(DefaultEmailNotifierTest::readAllBytes))
+            .assertNext(actual -> assertArrayEquals(content, actual))
+            .verifyComplete();
+
+        verify(fileManager).read("file-id");
+    }
+
+    @Test
+    void shouldKeepExplicitLocalAttachment() {
+        FileManager fileManager = mock(FileManager.class);
+        DefaultEmailNotifier notifier = createNotifier(fileManager);
+        notifier.setEnableFileSystemAttachment(true);
+
+        StepVerifier
+            .create(notifier.convertResource("/tmp/attachment.txt"))
+            .assertNext(resource -> {
+                FileSystemResource local = assertInstanceOf(FileSystemResource.class, resource);
+                assertEquals("/tmp/attachment.txt", local.getPath());
+            })
+            .verifyComplete();
+
+        verifyNoInteractions(fileManager);
+    }
+
+    @Test
+    void shouldKeepBase64Attachment() {
+        byte[] content = "base64-attachment".getBytes(StandardCharsets.UTF_8);
+        FileManager fileManager = mock(FileManager.class);
+        DefaultEmailNotifier notifier = createNotifier(fileManager);
+
+        StepVerifier
+            .create(notifier
+                        .convertResource("data:text/plain;base64," + Base64.getEncoder().encodeToString(content))
+                        .map(DefaultEmailNotifierTest::readAllBytes))
+            .assertNext(actual -> assertArrayEquals(content, actual))
+            .verifyComplete();
+
+        verifyNoInteractions(fileManager);
+    }
+
+    private static DefaultEmailNotifier createNotifier(FileManager fileManager) {
+        DefaultEmailProperties properties = new DefaultEmailProperties();
+        properties.setHost("localhost");
+        properties.setPort(25);
+        properties.setSender("test@example.com");
+        return new DefaultEmailNotifier(
+            "test",
+            properties,
+            mock(TemplateManager.class),
+            fileManager,
+            WebClient.builder()
+        );
+    }
+
+    private static byte[] readAllBytes(InputStreamSource resource) {
+        try (var stream = resource.getInputStream()) {
+            return stream.readAllBytes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/jetlinks-components/notify-component/notify-email/src/test/java/org/jetlinks/community/notify/email/embedded/DefaultEmailNotifierTest.java
+++ b/jetlinks-components/notify-component/notify-email/src/test/java/org/jetlinks/community/notify/email/embedded/DefaultEmailNotifierTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.notify.email.embedded;
+
+import org.jetlinks.community.io.file.FileManager;
+import org.jetlinks.community.notify.template.TemplateManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.mock;
+
+class DefaultEmailNotifierTest {
+
+    @Test
+    void shouldRejectRemoteAttachment() {
+        DefaultEmailProperties properties = new DefaultEmailProperties();
+        properties.setHost("localhost");
+        properties.setPort(25);
+        properties.setSender("test@example.com");
+
+        DefaultEmailNotifier notifier = new DefaultEmailNotifier(
+            "test",
+            properties,
+            mock(TemplateManager.class),
+            mock(FileManager.class),
+            WebClient.builder()
+        );
+
+        StepVerifier
+            .create(notifier.convertResource("http://127.0.0.1/internal"))
+            .expectError(UnsupportedOperationException.class)
+            .verify();
+    }
+}


### PR DESCRIPTION
## 目的

- 修复邮件模板附件可通过 HTTP/HTTPS URL 触发服务端远程请求的问题
- 将平台托管附件统一收敛到 #780 提供的 `FileUtils` managed-file 入口
- 保留平台文件 ID/访问地址、base64 附件及显式开启的本地附件能力

## 核心变动

- notify-email：移除基于 `WebClient` 的远程附件下载分支
- notify-email：平台文件 ID 或包含 `/file/{id}` 的访问地址统一通过 `FileUtils.readManagedInputStream` 和 `FileManager` 读取
- notify-email：附件读取完成后立即关闭托管输入流，再转换为邮件使用的内存资源
- notify-email：任意外部 URL 在调用 `FileManager` 前失败，不会发起网络请求
- notify-email：保留 base64 附件，以及 `email.attach.local-file.enabled` 显式开启后的本地附件
- 分支已同步最新 `2.12`，包含已合并的 #780

## 设计与测试目标

- 设计稿：不适用；本次为边界明确的小范围安全修复
- 用户确认：已确认，按独立 Issue 提交评审
- 测试目标：覆盖平台托管文件访问地址正常读取、外部 URL 拒绝且不调用 `FileManager`，以及 base64/显式本地附件兼容路径
- 注释 / 公共契约：适用；复用 #780 已定义的 `FileUtils` 托管文件安全契约，未新增公共 SPI
- 数据权限：不适用；未涉及资产数据访问
- 数据库兼容与性能：不适用；未涉及 SQL
- 链路追踪：不适用；删除远程 I/O 分支，未新增业务链路
- MBean 运维可观测性：不适用；未新增常驻任务、缓存、队列或后台执行器

## 测试结果

- 命令：`mvn -pl jetlinks-components/notify-component/notify-email -am -Dtest=DefaultEmailNotifierTest -Dsurefire.failIfNoSpecifiedTests=false test`
- 单元测试：4 passed, 0 failed, 0 errors, 0 skipped
- 覆盖路径：外部 URL 拒绝、平台托管文件 URL 读取、显式本地附件、base64 附件
- 覆盖率：`convertResource` 主方法 8/8 lines（100%）、3/4 branches（75%）；`DefaultEmailNotifier` 整类 39/133 lines（29.3%）、7/32 branches（21.9%）
- 集成测试：不适用；附件解析安全边界通过单元测试验证，未改变 SMTP 协议、消息、数据库或启动装配
- 压力测试：不适用；仍沿用原有聚合附件为内存资源的行为，不改变邮件发送吞吐模型
- 补充说明：使用项目目标 JDK 17 执行，JaCoCo 报告正常生成

## 文档同步情况

- 无需同步长期文档：附件来源安全边界由统一文件契约、代码和回归测试维护
- README 长期总览未发生变化；测试证据记录在 PR / CI

## 风险与说明

- 影响范围：邮件模板附件及内联图片资源解析
- 安全边界：HTTP/HTTPS 地址仅可作为平台托管文件访问地址解析 ID，不会直接下载
- 兼容性：继续支持裸文件 ID、绝对/相对平台文件访问地址、base64，以及显式启用的本地路径
- 已知限制：存量任意远程附件 URL 将失败，应先上传为平台托管文件
- 范围边界：通用远程下载策略不在本 PR 范围，本入口不会调用该能力

Closes #770