### PR TITLE
fix(通知管理): 限制 WebHook 模板目标地址

### DIFF
--- a/jetlinks-components/notify-component/notify-webhook/src/main/java/org/jetlinks/community/notify/webhook/http/HttpWebHookNotifier.java
+++ b/jetlinks-components/notify-component/notify-webhook/src/main/java/org/jetlinks/community/notify/webhook/http/HttpWebHookNotifier.java
@@ -29,6 +29,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import javax.annotation.Nonnull;
+import java.net.URI;
 
 public class HttpWebHookNotifier extends AbstractNotifier<HttpWebHookTemplate> {
     private final String id;
@@ -73,7 +74,7 @@ public class HttpWebHookNotifier extends AbstractNotifier<HttpWebHookTemplate> {
             .method(template.getMethod());
 
         if (StringUtils.hasText(template.getUrl())) {
-            bodyUriSpec.uri(template.getUrl());
+            bodyUriSpec.uri(resolveTemplateUri(template.getUrl()));
         }
         if (method == HttpMethod.POST
             || method == HttpMethod.PUT
@@ -101,6 +102,15 @@ public class HttpWebHookNotifier extends AbstractNotifier<HttpWebHookTemplate> {
         return bodyUriSpec
             .retrieve()
             .bodyToMono(Void.class);
+    }
+
+    URI resolveTemplateUri(String url) {
+        URI uri = URI.create(url);
+        // 模板只能补充相对路径，目标主机始终由具有配置权限的通知器配置决定。
+        if (uri.isAbsolute() || uri.getHost() != null || url.startsWith("//")) {
+            throw new IllegalArgumentException("WebHook template URL must be relative");
+        }
+        return uri;
     }
 
     @Nonnull

--- a/jetlinks-components/notify-component/notify-webhook/src/test/java/org/jetlinks/community/notify/webhook/http/HttpWebHookNotifierTest.java
+++ b/jetlinks-components/notify-component/notify-webhook/src/test/java/org/jetlinks/community/notify/webhook/http/HttpWebHookNotifierTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.notify.webhook.http;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class HttpWebHookNotifierTest {
+
+    private final HttpWebHookNotifier notifier = new HttpWebHookNotifier(
+        "test",
+        new HttpWebHookProperties(),
+        WebClient.builder().baseUrl("https://example.com/api").build(),
+        mock(org.jetlinks.community.notify.template.TemplateManager.class)
+    );
+
+    @Test
+    void shouldAcceptRelativeTemplateUrl() {
+        assertEquals(URI.create("events/device-1"), notifier.resolveTemplateUri("events/device-1"));
+    }
+
+    @Test
+    void shouldRejectAbsoluteTemplateUrl() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> notifier.resolveTemplateUri("http://127.0.0.1/internal")
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> notifier.resolveTemplateUri("//127.0.0.1/internal")
+        );
+    }
+}


### PR DESCRIPTION
## 目的

- 修复 HTTP WebHook 模板可使用绝对 URL 覆盖通知器目标 Host 的问题
- 保证请求目标始终由具备管理权限的通知器配置决定，模板仅描述相对路径

## 核心变动

- notify-webhook：发送前校验模板 URL，仅接受相对路径
- notify-webhook：新增绝对 HTTP/HTTPS URL 拒绝及合法相对路径的回归测试
- notify-webhook：保留既有模板渲染行为和通知器 Host 配置能力

## 设计与测试目标

- 设计稿：不适用；本次为边界明确的小范围安全修复
- 用户确认：已确认，按独立 Issue 提交评审
- 测试目标：覆盖相对路径正常发送、绝对 URL 拒绝，以及既有模板解析回归路径
- 注释 / 公共契约：适用；模板 URL 与通知器 Host 的职责边界已通过校验逻辑和异常信息明确
- 数据权限：不适用；未涉及资产数据访问
- 数据库兼容与性能：不适用；未涉及 SQL
- 链路追踪：不适用；沿用既有通知发送链路，未新增调用层级
- MBean 运维可观测性：不适用；未新增常驻任务、缓存、队列或后台执行器

## 测试结果

- 命令：`mvn -pl jetlinks-components/notify-component/notify-webhook -am -Dtest=HttpWebHookNotifierTest,HttpWebHookTemplateTest -Dsurefire.failIfNoSpecifiedTests=false test`
- 新增/更新测试：`HttpWebHookNotifierTest` 与既有 `HttpWebHookTemplateTest` 覆盖绝对 URL 拒绝、相对路径发送和模板解析回归
- 单元测试：5 passed, 0 failed, 0 skipped
- 集成测试：不适用；请求构造与拒绝分支通过可控 WebClient 单元测试验证，未改变第三方 WebHook 协议
- 压力测试：不适用；未改变通知吞吐或队列模型
- 覆盖率：changed class line 9/35（25.7%），branch 5/24（20.8%）

## 文档同步情况

- 已同步：无需同步长期文档；通知器 Host 与模板相对路径的边界由配置模型和校验维护
- 未同步：无
- 说明：README 长期总览未发生变化；测试证据仅记录在 PR / CI

## 风险与说明

- 影响范围：HTTP WebHook 通知发送
- 注释 / 公共契约：未新增 SPI；模板 URL 现限定为相对路径
- 链路追踪 / 可观测性：沿用既有通知链路
- MBean / 运维可观测性：不涉及
- 未覆盖场景：未访问真实第三方 WebHook，核心 URI 构造与安全边界已通过单元测试验证
- 已知限制：存量绝对 URL 模板需改为相对路径，目标 Host 继续在通知器配置中维护

Closes #767