### PR TITLE
fix(协议管理): 提升协议转换操作权限

### DIFF
--- a/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/web/ProtocolSupportController.java
+++ b/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/web/ProtocolSupportController.java
@@ -202,7 +202,8 @@ public class ProtocolSupportController
     }
 
     @PostMapping("/convert")
-    @QueryAction
+    // 转换过程会下载并加载协议包，必须使用写权限而不是普通查询权限。
+    @SaveAction
     @Hidden
     public Mono<ProtocolDetail> convertToDetail(@RequestParam(required = false) String transport, @RequestBody Mono<ProtocolSupportEntity> entity) {
         return entity.map(ProtocolSupportEntity::toDeployDefinition)

--- a/jetlinks-manager/device-manager/src/test/java/org/jetlinks/community/device/web/ProtocolSupportControllerTest.java
+++ b/jetlinks-manager/device-manager/src/test/java/org/jetlinks/community/device/web/ProtocolSupportControllerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.device.web;
+
+import org.hswebframework.web.authorization.annotation.QueryAction;
+import org.hswebframework.web.authorization.annotation.SaveAction;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProtocolSupportControllerTest {
+
+    @Test
+    void convertShouldRequireSavePermission() throws NoSuchMethodException {
+        Method method = ProtocolSupportController.class
+            .getDeclaredMethod("convertToDetail", String.class, Mono.class);
+
+        assertTrue(method.isAnnotationPresent(SaveAction.class));
+        assertFalse(method.isAnnotationPresent(QueryAction.class));
+    }
+}


### PR DESCRIPTION
## 目的

- 降低协议远程 JAR 转换能力被低权限查询用户滥用的风险
- 保留管理员通过远程协议仓库加载协议包的既有能力，不在应用层硬禁必要的内部网络访问

## 核心变动

- device-manager：将协议 /convert 接口权限由 QueryAction 提升为 SaveAction
- device-manager：新增反射测试，锁定转换接口必须具备保存权限且不再暴露为查询权限
- device-manager：不改变协议加载、转换及远程仓库实现

## 设计与测试目标

- 设计稿：不适用；本次为单一接口权限边界修复
- 用户确认：已确认，按独立 Issue 提交评审
- 测试目标：覆盖接口 SaveAction 正常权限声明，以及 QueryAction 不应存在的回归断言
- 注释 / 公共契约：适用；Controller 权限注解即接口授权契约，未新增 SPI
- 数据权限：不适用；本次调整功能权限，不涉及 AssetsHolder 资产数据权限
- 数据库兼容与性能：不适用；未涉及 SQL
- 链路追踪：不适用；未改变协议转换执行链路
- MBean 运维可观测性：不适用；未新增常驻任务、缓存、队列或后台执行器

## 测试结果

- 命令：`mvn -pl jetlinks-manager/device-manager -am -Dtest=ProtocolSupportControllerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- 新增/更新测试：`ProtocolSupportControllerTest` 通过反射验证 /convert 使用 SaveAction 且不再使用 QueryAction
- 单元测试：1 passed, 0 failed, 0 skipped
- 集成测试：不适用；仅变更静态权限注解，不涉及数据库、消息、协议实现、外部依赖或启动装配
- 压力测试：不适用；未改变执行路径或性能
- 覆盖率：changed class line 0%，branch 0%；测试通过反射验证注解契约，未执行 Controller 方法体，因此 JaCoCo 不记录目标类执行覆盖
- 补充说明：JaCoCo 0.8.7 在 JDK 21 对部分 JDK/Mockito 动态类报告 Unsupported class file major version 65，不影响目标测试结果

## 文档同步情况

- 已同步：无需同步长期文档；权限动作由 Controller 注解和权限系统维护
- 未同步：无
- 说明：README 长期总览未发生变化；测试证据仅记录在 PR / CI

## 风险与说明

- 影响范围：协议转换接口授权
- 注释 / 公共契约：权限注解已更新并由测试锁定
- 链路追踪 / 可观测性：不涉及执行链路变更
- MBean / 运维可观测性：不涉及
- 未覆盖场景：未启动完整权限网关；框架注解契约已通过反射测试验证
- 已知限制：原仅具备 protocol:query 的调用方需增加 protocol:save；管理员远程协议仓库能力保持不变

Closes #769