### PR TITLE
fix(设备管理): 限制物模型导入使用托管文件

### DIFF
--- a/jetlinks-components/io-component/src/main/java/org/jetlinks/community/io/excel/DefaultImportExportService.java
+++ b/jetlinks-components/io-component/src/main/java/org/jetlinks/community/io/excel/DefaultImportExportService.java
@@ -26,7 +26,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.io.InputStream;
-import java.net.URI;
 
 import static org.hswebframework.reactor.excel.ReactorExcel.read;
 
@@ -72,29 +71,6 @@ public class DefaultImportExportService implements ImportExportService {
     }
 
     public Mono<InputStream> getInputStream(String fileUrl) {
-        // 导入入口只接受平台托管文件 ID，避免由请求参数触发任意网络或本地文件访问。
-        return fileManager
-            .read(resolveFileId(fileUrl))
-            .as(DataBufferUtils::join)
-            .map(buffer -> buffer.asInputStream(true));
-    }
-
-    static String resolveFileId(String fileUrl) {
-        URI uri = URI.create(fileUrl);
-        if (!uri.isAbsolute()) {
-            if (fileUrl.contains("/") || fileUrl.contains("\\")) {
-                throw new IllegalArgumentException("Only managed file IDs are supported");
-            }
-            return fileUrl;
-        }
-
-        String path = uri.getPath();
-        int filePathIndex = path == null ? -1 : path.lastIndexOf("/file/");
-        if (filePathIndex < 0) {
-            throw new IllegalArgumentException("Only managed file URLs are supported");
-        }
-        String fileName = path.substring(filePathIndex + "/file/".length());
-        int extensionIndex = fileName.indexOf('.');
-        return extensionIndex > 0 ? fileName.substring(0, extensionIndex) : fileName;
+        return FileUtils.readManagedInputStream(fileManager, fileUrl);
     }
 }

--- a/jetlinks-components/io-component/src/main/java/org/jetlinks/community/io/excel/DefaultImportExportService.java
+++ b/jetlinks-components/io-component/src/main/java/org/jetlinks/community/io/excel/DefaultImportExportService.java
@@ -20,17 +20,13 @@ import org.hswebframework.utils.StringUtils;
 import org.jetlinks.community.io.excel.easyexcel.ExcelReadDataListener;
 import org.jetlinks.community.io.file.FileManager;
 import org.jetlinks.community.io.utils.FileUtils;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.net.URI;
 
 import static org.hswebframework.reactor.excel.ReactorExcel.read;
 
@@ -41,13 +37,9 @@ import static org.hswebframework.reactor.excel.ReactorExcel.read;
 @Component
 public class DefaultImportExportService implements ImportExportService {
 
-    private WebClient client;
-
     private final FileManager fileManager;
 
-    public DefaultImportExportService(WebClient.Builder builder,
-                                      FileManager fileManager) {
-        client = builder.build();
+    public DefaultImportExportService(FileManager fileManager) {
         this.fileManager = fileManager;
     }
 
@@ -80,19 +72,29 @@ public class DefaultImportExportService implements ImportExportService {
     }
 
     public Mono<InputStream> getInputStream(String fileUrl) {
+        // 导入入口只接受平台托管文件 ID，避免由请求参数触发任意网络或本地文件访问。
+        return fileManager
+            .read(resolveFileId(fileUrl))
+            .as(DataBufferUtils::join)
+            .map(buffer -> buffer.asInputStream(true));
+    }
 
-        return Mono.defer(() -> {
-            if (fileUrl.startsWith("http")) {
-                return client
-                    .get()
-                    .uri(fileUrl)
-                    .accept(MediaType.APPLICATION_OCTET_STREAM)
-                    .exchangeToMono(clientResponse -> clientResponse.bodyToMono(Resource.class))
-                    .flatMap(resource -> Mono.fromCallable(resource::getInputStream));
-            } else {
-                return Mono.fromCallable(() -> new FileInputStream(fileUrl));
+    static String resolveFileId(String fileUrl) {
+        URI uri = URI.create(fileUrl);
+        if (!uri.isAbsolute()) {
+            if (fileUrl.contains("/") || fileUrl.contains("\\")) {
+                throw new IllegalArgumentException("Only managed file IDs are supported");
             }
-        });
+            return fileUrl;
+        }
 
+        String path = uri.getPath();
+        int filePathIndex = path == null ? -1 : path.lastIndexOf("/file/");
+        if (filePathIndex < 0) {
+            throw new IllegalArgumentException("Only managed file URLs are supported");
+        }
+        String fileName = path.substring(filePathIndex + "/file/".length());
+        int extensionIndex = fileName.indexOf('.');
+        return extensionIndex > 0 ? fileName.substring(0, extensionIndex) : fileName;
     }
 }

--- a/jetlinks-components/io-component/src/main/java/org/jetlinks/community/io/utils/FileUtils.java
+++ b/jetlinks-components/io-component/src/main/java/org/jetlinks/community/io/utils/FileUtils.java
@@ -17,7 +17,9 @@ package org.jetlinks.community.io.utils;
 
 import io.netty.buffer.ByteBufAllocator;
 import org.apache.commons.io.FilenameUtils;
+import org.hswebframework.web.exception.ValidationException;
 import org.jetlinks.core.message.codec.http.HttpUtils;
+import org.jetlinks.community.io.file.FileManager;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
@@ -31,10 +33,18 @@ import reactor.core.publisher.Mono;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 
+/**
+ * 文件读取与媒体类型工具。
+ *
+ * 通用 URL 读取保留既有远程和本地文件能力；来自业务请求的托管文件必须通过
+ * {@link #readManagedInputStream(FileManager, String)} 读取，避免绕过 {@link FileManager}
+ * 直接访问网络或本地文件。
+ */
 public class FileUtils {
 
     public static String getExtension(String url) {
@@ -134,6 +144,77 @@ public class FileUtils {
                       }))
             .map(buffer -> buffer.asInputStream(true));
 
+    }
+
+    /**
+     * 读取平台托管文件。
+     *
+     * 仅接受 {@link FileManager} 文件 ID 或包含 {@code /file/{id}} 的平台文件访问地址。
+     * 访问地址只用于解析文件 ID，不会发起 HTTP 请求或读取本地路径。
+     *
+     * @param fileManager 文件管理器
+     * @param fileUrlOrId 平台文件访问地址或文件 ID
+     * @return 文件输入流，调用方使用完毕后必须关闭
+     */
+    public static Mono<InputStream> readManagedInputStream(FileManager fileManager,
+                                                           String fileUrlOrId) {
+        return Mono.defer(() -> dataBufferToInputStream(
+            fileManager.read(resolveManagedFileId(fileUrlOrId))
+        ));
+    }
+
+    /**
+     * 从平台文件访问地址或文件 ID 中解析托管文件 ID。
+     *
+     * @param fileUrlOrId 平台文件访问地址或文件 ID
+     * @return 托管文件 ID
+     * @throws ValidationException 输入不是托管文件 ID 或平台文件访问地址
+     */
+    public static String resolveManagedFileId(String fileUrlOrId) {
+        if (!StringUtils.hasText(fileUrlOrId)) {
+            throw unsupportedManagedFile();
+        }
+
+        URI uri;
+        try {
+            uri = URI.create(fileUrlOrId);
+        } catch (IllegalArgumentException e) {
+            throw unsupportedManagedFile();
+        }
+
+        String path = uri.getPath();
+        if (!uri.isAbsolute()
+            && !fileUrlOrId.contains("/")
+            && !fileUrlOrId.contains("\\")) {
+            if (uri.getQuery() == null
+                && uri.getFragment() == null
+                && StringUtils.hasText(path)) {
+                return path;
+            }
+            throw unsupportedManagedFile();
+        }
+
+        int filePathIndex = path == null ? -1 : path.lastIndexOf("/file/");
+        if (filePathIndex < 0) {
+            throw unsupportedManagedFile();
+        }
+
+        String fileName = path.substring(filePathIndex + "/file/".length());
+        if (!StringUtils.hasText(fileName)
+            || fileName.contains("/")
+            || fileName.contains("\\")) {
+            throw unsupportedManagedFile();
+        }
+
+        int extensionIndex = fileName.indexOf('.');
+        if (extensionIndex == 0) {
+            throw unsupportedManagedFile();
+        }
+        return extensionIndex > 0 ? fileName.substring(0, extensionIndex) : fileName;
+    }
+
+    private static ValidationException unsupportedManagedFile() {
+        return new ValidationException.NoStackTrace("error.only_managed_file_supported");
     }
 
     public static Flux<DataBuffer> readDataBuffer(WebClient client,

--- a/jetlinks-components/io-component/src/main/resources/i18n/io-component/messages_en.properties
+++ b/jetlinks-components/io-component/src/main/resources/i18n/io-component/messages_en.properties
@@ -2,3 +2,4 @@ excel.write.true.text=yes
 excel.write.false.text=no
 excel.read.true.text=yes
 excel.read.false.text=no
+error.only_managed_file_supported=Only managed file IDs or access URLs are supported

--- a/jetlinks-components/io-component/src/main/resources/i18n/io-component/messages_zh.properties
+++ b/jetlinks-components/io-component/src/main/resources/i18n/io-component/messages_zh.properties
@@ -2,3 +2,4 @@ excel.write.true.text=\u662f
 excel.write.false.text=\u5426
 excel.read.true.text=\u662f
 excel.read.false.text=\u5426
+error.only_managed_file_supported=\u4ec5\u652f\u6301\u5e73\u53f0\u6258\u7ba1\u6587\u4ef6ID\u6216\u8bbf\u95ee\u5730\u5740

--- a/jetlinks-components/io-component/src/test/java/org/jetlinks/community/io/excel/DefaultImportExportServiceTest.java
+++ b/jetlinks-components/io-component/src/test/java/org/jetlinks/community/io/excel/DefaultImportExportServiceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.io.excel;
+
+import org.jetlinks.community.io.file.FileManager;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DefaultImportExportServiceTest {
+
+    @Test
+    void shouldReadManagedFileInsteadOfRemoteUrl() {
+        FileManager fileManager = mock(FileManager.class);
+        when(fileManager.read("file-id")).thenReturn(Flux.empty());
+
+        DefaultImportExportService service = new DefaultImportExportService(fileManager);
+
+        StepVerifier
+            .create(service.getInputStream("http://localhost:8848/api/file/file-id.csv?accessKey=test"))
+            .verifyComplete();
+
+        verify(fileManager).read("file-id");
+    }
+
+    @Test
+    void shouldResolveManagedFileId() {
+        assertEquals("file-id", DefaultImportExportService.resolveFileId("file-id"));
+        assertEquals(
+            "file-id",
+            DefaultImportExportService.resolveFileId("http://localhost:8848/api/file/file-id.xlsx?accessKey=test")
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DefaultImportExportService.resolveFileId("http://127.0.0.1/internal/secret.csv")
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DefaultImportExportService.resolveFileId("/etc/passwd")
+        );
+    }
+}

--- a/jetlinks-components/io-component/src/test/java/org/jetlinks/community/io/excel/DefaultImportExportServiceTest.java
+++ b/jetlinks-components/io-component/src/test/java/org/jetlinks/community/io/excel/DefaultImportExportServiceTest.java
@@ -15,47 +15,119 @@
  */
 package org.jetlinks.community.io.excel;
 
+import org.hswebframework.web.exception.ValidationException;
 import org.jetlinks.community.io.file.FileManager;
+import org.jetlinks.community.io.utils.FileUtils;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class DefaultImportExportServiceTest {
 
     @Test
     void shouldReadManagedFileInsteadOfRemoteUrl() {
+        byte[] content = "managed-file".getBytes(StandardCharsets.UTF_8);
         FileManager fileManager = mock(FileManager.class);
-        when(fileManager.read("file-id")).thenReturn(Flux.empty());
+        when(fileManager.read("file-id"))
+            .thenReturn(Flux.just(DefaultDataBufferFactory.sharedInstance.wrap(content)));
 
         DefaultImportExportService service = new DefaultImportExportService(fileManager);
 
         StepVerifier
-            .create(service.getInputStream("http://localhost:8848/api/file/file-id.csv?accessKey=test"))
+            .create(service
+                        .getInputStream("http://localhost:8848/api/file/file-id.csv?accessKey=test")
+                        .map(DefaultImportExportServiceTest::readAllBytes))
+            .assertNext(actual -> assertArrayEquals(content, actual))
             .verifyComplete();
 
         verify(fileManager).read("file-id");
     }
 
     @Test
+    void shouldRejectExternalOrLocalFileBeforeReading() {
+        FileManager fileManager = mock(FileManager.class);
+        DefaultImportExportService service = new DefaultImportExportService(fileManager);
+
+        StepVerifier
+            .create(service.getInputStream("http://127.0.0.1/internal/secret.csv"))
+            .expectError(ValidationException.class)
+            .verify();
+        StepVerifier
+            .create(service.getInputStream("/etc/passwd"))
+            .expectError(ValidationException.class)
+            .verify();
+
+        verifyNoInteractions(fileManager);
+    }
+
+    @Test
     void shouldResolveManagedFileId() {
-        assertEquals("file-id", DefaultImportExportService.resolveFileId("file-id"));
+        assertEquals("file-id", FileUtils.resolveManagedFileId("file-id"));
         assertEquals(
             "file-id",
-            DefaultImportExportService.resolveFileId("http://localhost:8848/api/file/file-id.xlsx?accessKey=test")
+            FileUtils.resolveManagedFileId("http://localhost:8848/api/file/file-id.xlsx?accessKey=test")
+        );
+        assertEquals(
+            "file-id",
+            FileUtils.resolveManagedFileId("/api/file/file-id.xlsx?accessKey=test")
         );
         assertThrows(
-            IllegalArgumentException.class,
-            () -> DefaultImportExportService.resolveFileId("http://127.0.0.1/internal/secret.csv")
+            ValidationException.class,
+            () -> FileUtils.resolveManagedFileId("http://127.0.0.1/internal/secret.csv")
         );
         assertThrows(
-            IllegalArgumentException.class,
-            () -> DefaultImportExportService.resolveFileId("/etc/passwd")
+            ValidationException.class,
+            () -> FileUtils.resolveManagedFileId("/etc/passwd")
         );
+        assertThrows(
+            ValidationException.class,
+            () -> FileUtils.resolveManagedFileId("file:///etc/passwd")
+        );
+        assertThrows(
+            ValidationException.class,
+            () -> FileUtils.resolveManagedFileId(" ")
+        );
+        assertThrows(
+            ValidationException.class,
+            () -> FileUtils.resolveManagedFileId("/api/file/.xlsx")
+        );
+        assertThrows(
+            ValidationException.class,
+            () -> FileUtils.resolveManagedFileId("/api/file/")
+        );
+        assertThrows(
+            ValidationException.class,
+            () -> FileUtils.resolveManagedFileId("/api/file/file-id/extra.xlsx")
+        );
+        assertThrows(
+            ValidationException.class,
+            () -> FileUtils.resolveManagedFileId("file-id?accessKey=test")
+        );
+        assertThrows(
+            ValidationException.class,
+            () -> FileUtils.resolveManagedFileId("http://[::1")
+        );
+    }
+
+    private static byte[] readAllBytes(InputStream stream) {
+        try (stream) {
+            return stream.readAllBytes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/web/DeviceInstanceController.java
+++ b/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/web/DeviceInstanceController.java
@@ -1078,7 +1078,7 @@ public class DeviceInstanceController implements
     @SaveAction
     @Operation(summary = "解析文件为属性物模型")
     public Mono<String> importPropertyMetadata(@PathVariable @Parameter(description = "产品ID") String productId,
-                                               @RequestParam @Parameter(description = "文件地址,支持csv,xlsx文件格式") String fileUrl) {
+                                               @RequestParam @Parameter(description = "平台文件ID,支持csv,xlsx文件格式") String fileUrl) {
         return metadataManager
             .getMetadataExpandsConfig(productId, DeviceMetadataType.property, "*", "*", DeviceConfigScope.device)
             .collectList()

--- a/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/web/DeviceInstanceController.java
+++ b/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/web/DeviceInstanceController.java
@@ -1078,7 +1078,7 @@ public class DeviceInstanceController implements
     @SaveAction
     @Operation(summary = "解析文件为属性物模型")
     public Mono<String> importPropertyMetadata(@PathVariable @Parameter(description = "产品ID") String productId,
-                                               @RequestParam @Parameter(description = "平台文件ID,支持csv,xlsx文件格式") String fileUrl) {
+                                               @RequestParam @Parameter(description = "平台文件ID或访问地址,支持csv,xlsx文件格式") String fileUrl) {
         return metadataManager
             .getMetadataExpandsConfig(productId, DeviceMetadataType.property, "*", "*", DeviceConfigScope.device)
             .collectList()

--- a/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/web/DeviceProductController.java
+++ b/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/web/DeviceProductController.java
@@ -336,7 +336,7 @@ public class DeviceProductController implements ReactiveServiceCrudController<De
     @SaveAction
     @Operation(summary = "解析文件为属性物模型")
     public Mono<String> importPropertyMetadata(@PathVariable @Parameter(description = "产品ID") String productId,
-                                               @RequestParam @Parameter(description = "文件地址,支持csv,xlsx文件格式") String fileUrl) {
+                                               @RequestParam @Parameter(description = "平台文件ID,支持csv,xlsx文件格式") String fileUrl) {
         return configMetadataManager
             .getMetadataExpandsConfig(productId, DeviceMetadataType.property, "*", "*", DeviceConfigScope.product)
             .collectList()

--- a/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/web/DeviceProductController.java
+++ b/jetlinks-manager/device-manager/src/main/java/org/jetlinks/community/device/web/DeviceProductController.java
@@ -336,7 +336,7 @@ public class DeviceProductController implements ReactiveServiceCrudController<De
     @SaveAction
     @Operation(summary = "解析文件为属性物模型")
     public Mono<String> importPropertyMetadata(@PathVariable @Parameter(description = "产品ID") String productId,
-                                               @RequestParam @Parameter(description = "平台文件ID,支持csv,xlsx文件格式") String fileUrl) {
+                                               @RequestParam @Parameter(description = "平台文件ID或访问地址,支持csv,xlsx文件格式") String fileUrl) {
         return configMetadataManager
             .getMetadataExpandsConfig(productId, DeviceMetadataType.property, "*", "*", DeviceConfigScope.product)
             .collectList()


### PR DESCRIPTION
## 目的

- 修复属性物模型导入可通过 `fileUrl` 发起任意远程请求或读取本地路径的问题
- 将业务请求中的导入数据源收敛到平台 `FileManager` 托管文件，保留上传后导入流程
- 统一托管文件读取入口，避免各业务模块重复解析文件地址

## 核心变动

- io-component：在 `FileUtils` 新增 `readManagedInputStream(FileManager, String)` 和 `resolveManagedFileId(String)`
- io-component：统一入口仅解析裸文件 ID 或包含 `/file/{id}` 的平台文件访问地址，随后直接调用 `FileManager`；不会发起 HTTP 请求或读取本地路径
- io-component：`DefaultImportExportService` 改用统一托管文件入口，删除内部重复解析逻辑
- io-component：非法输入统一抛出支持 i18n 的 `ValidationException`
- device-manager：产品和设备属性导入接口说明同步为“平台文件 ID 或访问地址”
- 测试：覆盖真实流读取与关闭、绝对/相对托管访问地址解析，以及外部 URL、本地路径、畸形 URI 等输入被拒绝且不调用 `FileManager`

## 设计与测试目标

- 设计稿：不适用；本次为边界明确的小范围安全修复
- 用户确认：已确认，按独立 Issue 提交评审
- 测试目标：覆盖托管文件 ID、托管访问 URL 的正常路径，以及外部 URL / 本地路径不再被直接读取的异常与回归路径
- 注释 / 公共契约：适用；已补充 `FileUtils` 类级安全边界和新增公共方法契约
- i18n：适用；新增非法托管文件输入的中英文提示
- 数据权限：不适用；未新增资产查询或 CRUD 权限边界
- 数据库兼容与性能：不适用；未涉及 SQL
- 链路追踪：不适用；沿用既有导入链路，未新增业务或跨服务链路
- MBean 运维可观测性：不适用；未新增常驻任务、缓存、队列或后台执行器

## 测试结果

- 单元测试命令：`mvn -pl jetlinks-components/io-component -am -Dtest=DefaultImportExportServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- 单元测试：3 passed, 0 failed, 0 errors, 0 skipped
- 相关模块编译命令：`mvn -pl jetlinks-manager/device-manager -am -DskipTests compile`
- 相关模块编译：18 个 reactor module 全部成功
- 覆盖率：新增 `readManagedInputStream` 1/1 lines（100%）；`resolveManagedFileId` 27/27 lines（100%）、22/28 branches（78.6%）
- 集成测试：不适用；`FileManager` 交互已通过单元测试替身验证，未改变数据库、消息、事件、协议或启动装配
- 压力测试：不适用；未改变导入批处理算法
- 补充说明：JaCoCo 0.8.7 在 JDK 21 对 Mockito 动态类提示 `Unsupported class file major version 65`，不影响测试结果及目标类报告生成

## 文档同步情况

- 已同步：Controller OpenAPI 参数说明及 io-component 中英文错误提示
- 无需同步长期文档：接口仍使用既有上传文件后导入流程，README 总览未发生变化

## 风险与说明

- 影响范围：产品与设备属性物模型文件导入
- 安全边界：业务请求只可通过本 PR 新增的 managed-file 专用入口访问托管文件
- 兼容性：支持直接传文件 ID，以及绝对或相对的平台文件访问地址
- 已知限制：历史上直接传入任意外部 URL 或本地路径的调用将失败，应先上传为平台托管文件
- 范围边界：`FileUtils` 既有通用远程/本地读取能力及其全局下载策略不在本 PR 范围；本入口不会调用该能力

Closes #766