### PR TITLE
fix(docker): 加固 Compose 默认配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ application-local.yml
 dev/
 .DS_Store
 .java-version
+docker/dev-env/.env
+docker/run-all/.env

--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ TCP/UDP/MQTT/HTTP、TLS/DTLS、不同厂商、不同设备、不同报文、统�
 ------|----simulator            # 设备模拟器
 ```
 
+## Docker 部署说明
+
+生产环境请使用 `docker/run-all`，可直接启动；如用于生产，请先复制 `docker/run-all/.env.example` 为 `.env` 并覆盖为随机强密码：
+
+```bash
+cd docker/run-all
+cp .env.example .env
+docker compose up -d
+```
+
+生产 Compose 仅发布 JetLinks 对外服务端口，PostgreSQL 和 Redis 不映射到宿主机，平台通过 Compose 内部的 `postgres:5432` 和 `redis:6379` 访问。未配置密码时 Compose 会使用文件中的演示密码并允许启动，仅用于快速体验；生产环境必须通过 `.env` 或环境变量覆盖数据库、Redis 以及 admin 初始密码，`.env` 不要提交到代码仓库。
+
+`docker/dev-env` 仅用于本机开发调试，会保留 PostgreSQL `5432` 和 Redis `6379` 端口映射；不配置密码也可以启动，但会使用演示密码。生产环境不要使用该 Compose 配置，并应填写 `docker/dev-env/.env.example` 覆盖密码。
+
+已有 PostgreSQL 数据目录不会因为修改 `POSTGRES_PASSWORD` 环境变量自动修改数据库密码；迁移已有部署时，请使用数据库管理工具显式执行 `ALTER ROLE postgres WITH PASSWORD '新密码';`，并同步更新 `.env`。admin 初始密码同样只在首次初始化时生效。
+
 ## 服务支持
 
 我们提供了各种服务方式帮助您深入了解物联网平台和代码，通过产品文档、技术交流群、付费教学等方式，你将获得如下服务：
@@ -127,4 +143,3 @@ TCP/UDP/MQTT/HTTP、TLS/DTLS、不同厂商、不同设备、不同报文、统�
 [开发文档](https://hanta.yuque.com/px7kg1/nn1gdr)
 
 [![Stargazers over time](https://starchart.cc/jetlinks/jetlinks-community.svg?variant=adaptive)](https://starchart.cc/jetlinks/jetlinks-community)
-

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ cp .env.example .env
 docker compose up -d
 ```
 
-生产 Compose 仅发布 JetLinks 对外服务端口，PostgreSQL 和 Redis 不映射到宿主机，平台通过 Compose 内部的 `postgres:5432` 和 `redis:6379` 访问。未配置密码时 Compose 会使用文件中的演示密码并允许启动，仅用于快速体验；生产环境必须通过 `.env` 或环境变量覆盖数据库、Redis 以及 admin 初始密码，`.env` 不要提交到代码仓库。
+生产 Compose 仅发布 JetLinks 对外服务端口，PostgreSQL 和 Redis 不映射到宿主机，平台通过 Compose 内部的 `postgres:5432` 和 `redis:6379` 访问。未配置密码时 Compose 会沿用原有默认值并可直接启动，便于已有部署升级；生产环境建议通过 `.env` 或环境变量覆盖数据库、Redis 以及 admin 初始密码，`.env` 不要提交到代码仓库。
 
-`docker/dev-env` 仅用于本机开发调试，会保留 PostgreSQL `5432` 和 Redis `6379` 端口映射；不配置密码也可以启动，但会使用演示密码。生产环境不要使用该 Compose 配置，并应填写 `docker/dev-env/.env.example` 覆盖密码。
+`docker/dev-env` 仅用于本机开发调试，会保留 PostgreSQL `5432` 和 Redis `6379` 端口映射；PostgreSQL 未配置密码时沿用原有默认值，Redis 默认不设置密码。生产环境不要使用该 Compose 配置，并应填写 `docker/dev-env/.env.example` 覆盖 PostgreSQL 密码。
 
 已有 PostgreSQL 数据目录不会因为修改 `POSTGRES_PASSWORD` 环境变量自动修改数据库密码；迁移已有部署时，请使用数据库管理工具显式执行 `ALTER ROLE postgres WITH PASSWORD '新密码';`，并同步更新 `.env`。admin 初始密码同样只在首次初始化时生效。
 

--- a/docker/dev-env/.env.example
+++ b/docker/dev-env/.env.example
@@ -1,0 +1,5 @@
+# 可直接启动；留空时使用 Compose 内置演示密码。
+# 生产环境请填写随机强密码，.env 不要提交到代码仓库。
+# 可使用密码管理器或 openssl rand -base64 32 生成密码。
+POSTGRES_PASSWORD=
+REDIS_PASSWORD=

--- a/docker/dev-env/.env.example
+++ b/docker/dev-env/.env.example
@@ -1,5 +1,4 @@
-# 可直接启动；留空时使用 Compose 内置演示密码。
-# 生产环境请填写随机强密码，.env 不要提交到代码仓库。
+# 可直接启动；留空时沿用原有默认值。
+# 生产环境建议填写随机强密码，.env 不要提交到代码仓库。
 # 可使用密码管理器或 openssl rand -base64 32 生成密码。
 POSTGRES_PASSWORD=
-REDIS_PASSWORD=

--- a/docker/dev-env/docker-compose.yml
+++ b/docker/dev-env/docker-compose.yml
@@ -3,22 +3,32 @@ services:
     redis:
         image: redis:6
         container_name: jetlinks-ce-redis
+        # 仅供本地开发调试，生产环境不得发布 Redis 端口。
         ports:
             - "6379:6379"
         volumes:
             - "./data/redis:/data"
-        command: redis-server --appendonly yes
+        # 未设置 REDIS_PASSWORD 时使用演示密码，仅用于本地快速启动，生产环境请覆盖。
+        command:
+            - redis-server
+            - --appendonly
+            - "yes"
+            - --requirepass
+            - "${REDIS_PASSWORD:-JetLinks@redis-2026}"
         environment:
-            - TZ=Asia/Shanghai
+            REDIS_PASSWORD: ${REDIS_PASSWORD:-JetLinks@redis-2026}
+            TZ: Asia/Shanghai
     postgres:
         image: timescale/timescaledb:latest-pg16
         container_name: jetlinks-postgres-16
+        # 仅供本地开发调试，生产环境不得发布 PostgreSQL 端口。
         ports:
             - "5432:5432"
         volumes:
             - "./data/postgres:/var/lib/postgresql/data"
         environment:
-            POSTGRES_PASSWORD: jetlinks
+            # 未设置 POSTGRES_PASSWORD 时使用演示密码，仅用于本地快速启动，生产环境请覆盖。
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-JetLinks@postgres-2026}
             POSTGRES_DB: jetlinks
-            POSTGRES_HOST_AUTH_METHOD: trust
+            POSTGRES_HOST_AUTH_METHOD: scram-sha-256
             TZ: Asia/Shanghai

--- a/docker/dev-env/docker-compose.yml
+++ b/docker/dev-env/docker-compose.yml
@@ -8,16 +8,10 @@ services:
             - "6379:6379"
         volumes:
             - "./data/redis:/data"
-        # 未设置 REDIS_PASSWORD 时使用演示密码，仅用于本地快速启动，生产环境请覆盖。
-        command:
-            - redis-server
-            - --appendonly
-            - "yes"
-            - --requirepass
-            - "${REDIS_PASSWORD:-JetLinks@redis-2026}"
+        # 本地开发默认不设置 Redis 密码，生产环境请使用 docker/run-all 并配置密码。
+        command: redis-server --appendonly yes
         environment:
-            REDIS_PASSWORD: ${REDIS_PASSWORD:-JetLinks@redis-2026}
-            TZ: Asia/Shanghai
+            - TZ=Asia/Shanghai
     postgres:
         image: timescale/timescaledb:latest-pg16
         container_name: jetlinks-postgres-16
@@ -27,8 +21,8 @@ services:
         volumes:
             - "./data/postgres:/var/lib/postgresql/data"
         environment:
-            # 未设置 POSTGRES_PASSWORD 时使用演示密码，仅用于本地快速启动，生产环境请覆盖。
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-JetLinks@postgres-2026}
+            # 未设置 POSTGRES_PASSWORD 时沿用原有默认值，生产环境建议覆盖。
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-jetlinks}
             POSTGRES_DB: jetlinks
             POSTGRES_HOST_AUTH_METHOD: scram-sha-256
             TZ: Asia/Shanghai

--- a/docker/run-all/.env.example
+++ b/docker/run-all/.env.example
@@ -1,0 +1,6 @@
+# 可直接启动；留空时使用 Compose 内置演示密码。
+# 生产环境请填写随机强密码，.env 不要提交到代码仓库。
+# 可使用密码管理器或 openssl rand -base64 32 生成密码。
+POSTGRES_PASSWORD=
+REDIS_PASSWORD=
+ADMIN_USER_PASSWORD=

--- a/docker/run-all/.env.example
+++ b/docker/run-all/.env.example
@@ -1,5 +1,5 @@
-# 可直接启动；留空时使用 Compose 内置演示密码。
-# 生产环境请填写随机强密码，.env 不要提交到代码仓库。
+# 可直接启动；留空时沿用原有默认值。
+# 生产环境建议填写随机强密码，.env 不要提交到代码仓库。
 # 可使用密码管理器或 openssl rand -base64 32 生成密码。
 POSTGRES_PASSWORD=
 REDIS_PASSWORD=

--- a/docker/run-all/docker-compose.yml
+++ b/docker/run-all/docker-compose.yml
@@ -3,29 +3,35 @@ services:
     redis:
         image: redis:6
         container_name: jetlinks-ce-redis
-        #    ports:
-        #      - "6379:6379" # 仅供jetlinks-ce访问
         volumes:
             - "./data/redis:/data"
-        command: redis-server --appendonly yes --requirepass "JetLinks@redis"
+        # 不发布 Redis 端口，仅允许 Compose 内部服务通过 redis:6379 访问。
+        # 未设置 REDIS_PASSWORD 时使用演示密码，仅用于快速启动，生产环境请覆盖。
+        command:
+            - redis-server
+            - --appendonly
+            - "yes"
+            - --requirepass
+            - "${REDIS_PASSWORD:-JetLinks@redis-2026}"
         environment:
-            - TZ=Asia/Shanghai
+            REDIS_PASSWORD: ${REDIS_PASSWORD:-JetLinks@redis-2026}
+            TZ: Asia/Shanghai
         healthcheck:
-            test: [ "CMD", "redis-cli", "-h", "localhost", "-p", "6379", "-a", "JetLinks@redis", "ping" ]
+            test: [ "CMD-SHELL", "redis-cli -h localhost -p 6379 -a \"$${REDIS_PASSWORD}\" ping" ]
             interval: 10s
             timeout: 5s
             retries: 3
     postgres:
         image: timescale/timescaledb:latest-pg16
         container_name: jetlinks-ce-postgres
-        #        ports:
-        #            - "5432:5432"  # 仅供jetlinks-ce访问
         volumes:
             - "./data/postgres:/var/lib/postgresql/data"
         environment:
-            POSTGRES_PASSWORD: JetLinks@postgres
+            # 不发布 PostgreSQL 端口，仅允许 JetLinks 通过 postgres:5432 访问。
+            # 未设置 POSTGRES_PASSWORD 时使用演示密码，仅用于快速启动，生产环境请覆盖。
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-JetLinks@postgres-2026}
             POSTGRES_DB: jetlinks
-            POSTGRES_HOST_AUTH_METHOD: trust
+            POSTGRES_HOST_AUTH_METHOD: scram-sha-256
             TZ: Asia/Shanghai
         healthcheck:
             test: [ "CMD", "pg_isready", "-U", "postgres" ]
@@ -47,14 +53,14 @@ services:
             - "TZ=Asia/Shanghai"
             - "EXTERNAL_HOST=local-host.cn" # 对外提供访问的域名或者ip地址
             - "EXTERNAL_PORT=8848" # 对外提供访问的端口,修改了端口映射同时也需要修改这里.
-            - "ADMIN_USER_PASSWORD=JetLinks.C0mmVn1ty" # admin用户的初始密码
+            - "ADMIN_USER_PASSWORD=${ADMIN_USER_PASSWORD:-JetLinks.C0mmVn1ty-2026}" # 未设置时使用演示密码，生产环境请覆盖
             - "spring.r2dbc.url=r2dbc:postgresql://postgres:5432/jetlinks" #数据库连接地址
             - "spring.r2dbc.username=postgres"
-            - "spring.r2dbc.password=JetLinks@postgres"
+            - "spring.r2dbc.password=${POSTGRES_PASSWORD:-JetLinks@postgres-2026}"
             - "spring.data.redis.host=redis"
             - "spring.data.redis.port=6379"
             - "file.manager.storage-base-path=/application/data/files"
-            - "spring.data.redis.password=JetLinks@redis"
+            - "spring.data.redis.password=${REDIS_PASSWORD:-JetLinks@redis-2026}"
             - "logging.level.io.r2dbc=warn"
             - "logging.level.org.springframework.data=warn"
             - "logging.level.org.springframework=warn"
@@ -89,4 +95,3 @@ services:
 #        environment:
 #            API_BASE_PATH: "http://jetlinks:8848/"
 #            TZ: Asia/Shanghai
-

--- a/docker/run-all/docker-compose.yml
+++ b/docker/run-all/docker-compose.yml
@@ -6,15 +6,15 @@ services:
         volumes:
             - "./data/redis:/data"
         # 不发布 Redis 端口，仅允许 Compose 内部服务通过 redis:6379 访问。
-        # 未设置 REDIS_PASSWORD 时使用演示密码，仅用于快速启动，生产环境请覆盖。
+        # 未设置 REDIS_PASSWORD 时沿用原有默认值，生产环境建议覆盖。
         command:
             - redis-server
             - --appendonly
             - "yes"
             - --requirepass
-            - "${REDIS_PASSWORD:-JetLinks@redis-2026}"
+            - "${REDIS_PASSWORD:-JetLinks@redis}"
         environment:
-            REDIS_PASSWORD: ${REDIS_PASSWORD:-JetLinks@redis-2026}
+            REDIS_PASSWORD: ${REDIS_PASSWORD:-JetLinks@redis}
             TZ: Asia/Shanghai
         healthcheck:
             test: [ "CMD-SHELL", "redis-cli -h localhost -p 6379 -a \"$${REDIS_PASSWORD}\" ping" ]
@@ -28,8 +28,8 @@ services:
             - "./data/postgres:/var/lib/postgresql/data"
         environment:
             # 不发布 PostgreSQL 端口，仅允许 JetLinks 通过 postgres:5432 访问。
-            # 未设置 POSTGRES_PASSWORD 时使用演示密码，仅用于快速启动，生产环境请覆盖。
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-JetLinks@postgres-2026}
+            # 未设置 POSTGRES_PASSWORD 时沿用原有默认值，生产环境建议覆盖。
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-JetLinks@postgres}
             POSTGRES_DB: jetlinks
             POSTGRES_HOST_AUTH_METHOD: scram-sha-256
             TZ: Asia/Shanghai
@@ -53,14 +53,14 @@ services:
             - "TZ=Asia/Shanghai"
             - "EXTERNAL_HOST=local-host.cn" # 对外提供访问的域名或者ip地址
             - "EXTERNAL_PORT=8848" # 对外提供访问的端口,修改了端口映射同时也需要修改这里.
-            - "ADMIN_USER_PASSWORD=${ADMIN_USER_PASSWORD:-JetLinks.C0mmVn1ty-2026}" # 未设置时使用演示密码，生产环境请覆盖
+            - "ADMIN_USER_PASSWORD=${ADMIN_USER_PASSWORD:-JetLinks.C0mmVn1ty}" # 未设置时沿用原有默认值，生产环境建议覆盖
             - "spring.r2dbc.url=r2dbc:postgresql://postgres:5432/jetlinks" #数据库连接地址
             - "spring.r2dbc.username=postgres"
-            - "spring.r2dbc.password=${POSTGRES_PASSWORD:-JetLinks@postgres-2026}"
+            - "spring.r2dbc.password=${POSTGRES_PASSWORD:-JetLinks@postgres}"
             - "spring.data.redis.host=redis"
             - "spring.data.redis.port=6379"
             - "file.manager.storage-base-path=/application/data/files"
-            - "spring.data.redis.password=${REDIS_PASSWORD:-JetLinks@redis-2026}"
+            - "spring.data.redis.password=${REDIS_PASSWORD:-JetLinks@redis}"
             - "logging.level.io.r2dbc=warn"
             - "logging.level.org.springframework.data=warn"
             - "logging.level.org.springframework=warn"

--- a/jetlinks-standalone/src/main/resources/application-default.yml
+++ b/jetlinks-standalone/src/main/resources/application-default.yml
@@ -5,13 +5,13 @@ DB_HOST: 127.0.0.1 # postgresql 数据库地址
 DB_PORT: 5432 # postgresql 数据库端口
 DB_DATABASE: jetlinks # postgresql 数据库名
 DB_USERNAME: postgres # postgresql 数据库用户名
-DB_PASSWORD: JetLinks@postgres-2026 # postgresql 数据库密码,生产环境请覆盖
+DB_PASSWORD: jetlinks # postgresql 数据库密码
 DB_SCHEMA: public # postgresql 数据库schema,默认public
 DB_DIALECT: postgres # 数据库方言,默认postgres. 支持postgres,mysql,oracle,sqlserver等.
 # redis 相关配置
 REDIS_HOST: 127.0.0.1
 REDIS_PORT: 6379 # redis 数据库地址
-REDIS_PASSWORD: JetLinks@redis-2026 # redis 密码,生产环境请覆盖
+REDIS_PASSWORD: "" # redis 密码
 REDIS_DATABASE: 0 # redis 数据库索引
 
 # timescalbedb相关配置

--- a/jetlinks-standalone/src/main/resources/application-default.yml
+++ b/jetlinks-standalone/src/main/resources/application-default.yml
@@ -5,13 +5,13 @@ DB_HOST: 127.0.0.1 # postgresql 数据库地址
 DB_PORT: 5432 # postgresql 数据库端口
 DB_DATABASE: jetlinks # postgresql 数据库名
 DB_USERNAME: postgres # postgresql 数据库用户名
-DB_PASSWORD: jetlinks # postgresql 数据库密码
+DB_PASSWORD: JetLinks@postgres-2026 # postgresql 数据库密码,生产环境请覆盖
 DB_SCHEMA: public # postgresql 数据库schema,默认public
 DB_DIALECT: postgres # 数据库方言,默认postgres. 支持postgres,mysql,oracle,sqlserver等.
 # redis 相关配置
 REDIS_HOST: 127.0.0.1
 REDIS_PORT: 6379 # redis 数据库地址
-REDIS_PASSWORD: "" # redis 密码
+REDIS_PASSWORD: JetLinks@redis-2026 # redis 密码,生产环境请覆盖
 REDIS_DATABASE: 0 # redis 数据库索引
 
 # timescalbedb相关配置

--- a/jetlinks-standalone/src/main/resources/application.yml
+++ b/jetlinks-standalone/src/main/resources/application.yml
@@ -33,7 +33,7 @@ spring:
         # 注意:切换了数据库easyorm相关配置也要修改
         # url: r2dbc:mysql://${DB_HOST:127.0.0.1}:${DB_PORT:3306}/${DB_DATABASE}?ssl=false&serverZoneId=Asia/Shanghai
         username: ${DB_USERNAME:postgres}
-        password: ${DB_PASSWORD:JetLinks@postgres-2026}
+        password: ${DB_PASSWORD:jetlinks}
         pool:
             max-size: 128
             max-idle-time: 2m # 值不能大于mysql server的wait_timeout配置
@@ -157,7 +157,7 @@ jetlinks:
         enabled: true
         users: # 系统初始用户密码
             -   username: admin
-                password: ${ADMIN_USER_PASSWORD:JetLinks.C0mmVn1ty-2026}
+                password: ${ADMIN_USER_PASSWORD:JetLinks.C0mmVn1ty}
                 name: Administrator
                 type: admin
 rule:

--- a/jetlinks-standalone/src/main/resources/application.yml
+++ b/jetlinks-standalone/src/main/resources/application.yml
@@ -33,7 +33,7 @@ spring:
         # 注意:切换了数据库easyorm相关配置也要修改
         # url: r2dbc:mysql://${DB_HOST:127.0.0.1}:${DB_PORT:3306}/${DB_DATABASE}?ssl=false&serverZoneId=Asia/Shanghai
         username: ${DB_USERNAME:postgres}
-        password: ${DB_PASSWORD:jetlinks}
+        password: ${DB_PASSWORD:JetLinks@postgres-2026}
         pool:
             max-size: 128
             max-idle-time: 2m # 值不能大于mysql server的wait_timeout配置
@@ -157,7 +157,7 @@ jetlinks:
         enabled: true
         users: # 系统初始用户密码
             -   username: admin
-                password: ${ADMIN_USER_PASSWORD:JetLinks.C0mmVn1ty}
+                password: ${ADMIN_USER_PASSWORD:JetLinks.C0mmVn1ty-2026}
                 name: Administrator
                 type: admin
 rule:


### PR DESCRIPTION
## 目的

- 优化 Docker Compose 的 PostgreSQL 认证与生产端口暴露配置
- 保持原有默认凭据，避免已有部署升级后因默认密码变化无法使用
- 通过提示引导生产环境覆盖密码，同时保留未配置时可直接启动的体验

## 核心变动

- `docker/dev-env`：PostgreSQL 使用 `scram-sha-256`，保留 PostgreSQL `5432` 和 Redis `6379` 端口映射供本地调试
- `docker/run-all`：移除 PostgreSQL `5432` 和 Redis `6379` 宿主机端口映射，仅保留 JetLinks 对外端口
- 两份 Compose：支持通过环境变量覆盖密码；未配置时沿用原有默认值并可直接启动
- Redis：使用参数列表传递密码，避免特殊字符被 Shell 解析；健康检查读取容器环境变量
- 新增 `.env.example`，并补充 README 部署、密码提示和已有数据迁移说明
- 基准分支：`2.12`

## 设计与测试目标

- 设计稿：不适用，本次为小范围 Docker 配置与部署文档调整
- 用户确认：已确认
- 测试目标：无环境变量可解析、环境变量可覆盖密码、生产数据库与 Redis 端口不发布、SCRAM 配置生效、应用可连接 PostgreSQL 和 Redis
- 注释 / 公共契约：不适用；已在 Compose 安全边界和密码覆盖处补充配置说明
- 数据权限：不适用
- 数据库兼容与性能：不适用；未修改 SQL 或数据库业务逻辑
- 链路追踪：不适用
- MBean 运维可观测性：不适用

## 测试结果

- `docker compose config --quiet`：`docker/dev-env`、`docker/run-all` 均通过
- Compose JSON 断言：生产 `postgres`、`redis` 端口均为空；开发环境两个端口均保留；两份 Compose 均为 `scram-sha-256`
- 环境变量覆盖：生产 PostgreSQL 密码覆盖后同步出现在 PostgreSQL 和 JetLinks R2DBC 配置中
- PostgreSQL 连接：临时容器通过 `postgres:5432` TCP 密码连接成功，角色密码确认为 SCRAM-SHA-256
- 应用连接：使用同款 JetLinks `2.11.0-SNAPSHOT` 镜像、隔离 PostgreSQL/Redis 和临时测试凭据启动成功，完成 R2DBC 初始化且未出现数据库或 Redis 连接/认证错误
- `git diff --check`：通过
- 单元测试：0 executed；不适用，本次未修改 Java 代码逻辑
- Maven 集成测试：不适用；已完成 Docker 隔离环境下的应用依赖连接验证
- 压力测试：不适用
- 覆盖率：不适用；本次未修改 Java 源代码

## 文档同步情况

- 已同步：`README.md`、`docker/dev-env/.env.example`、`docker/run-all/.env.example`
- 未同步：无
- 说明：README 补充生产/开发端口边界、默认值兼容提示及已有 PostgreSQL 数据目录迁移说明

## 风险与说明

- 影响范围：Docker Compose 启动配置、standalone 默认连接配置和部署说明
- 默认凭据：保持原有值；生产环境建议通过 `.env` 或环境变量覆盖，未配置时仍可直接启动
- 已有 PostgreSQL 数据目录不会因修改 `POSTGRES_PASSWORD` 环境变量自动修改数据库密码；如需变更请显式执行密码迁移并同步更新配置
- 未涉及公共 Java 契约、链路追踪、MBean 或业务 SQL
