### PR TITLE
fix(网络组件): 修复MQTT直连设备下行全部失败(握手期isAlive误判失活)

### DIFF
--- a/jetlinks-components/network-component/mqtt-component/src/main/java/org/jetlinks/community/network/mqtt/gateway/device/session/MqttConnectionSession.java
+++ b/jetlinks-components/network-component/mqtt-component/src/main/java/org/jetlinks/community/network/mqtt/gateway/device/session/MqttConnectionSession.java
@@ -98,9 +98,10 @@ public class MqttConnectionSession extends CopyOnWriteArrayList<MqttConnection>
             connection.reject(MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE);
             return;
         }
-        if (!connection.isAlive()) {
-            return;
-        }
+        //不能在此以 isAlive() 做准入判断:注册发生在 CONNACK(accept)之前,
+        //该守卫会把握手中的新连接静默丢弃,造成上行正常而全部下行报"设备连接已断开"。
+        //握手期连接的存活语义由 VertxMqttConnection.isAlive()(closed 标志)保证,
+        //失活连接由 takeConnection/onClose 兜底清理。
         this.add(connection);
         connectTime = System.currentTimeMillis();
         connection.onClose(this);

--- a/jetlinks-components/network-component/mqtt-component/src/main/java/org/jetlinks/community/network/mqtt/server/vertx/VertxMqttConnection.java
+++ b/jetlinks-components/network-component/mqtt-component/src/main/java/org/jetlinks/community/network/mqtt/server/vertx/VertxMqttConnection.java
@@ -83,6 +83,16 @@ class VertxMqttConnection implements MqttConnection {
     public VertxMqttConnection(MqttEndpoint endpoint) {
         this.endpoint = endpoint;
         this.keepAliveTimeoutMs = (endpoint.keepAliveTimeSeconds() + 10) * 1000L;
+        //accept(CONNACK)之前 isAlive() 依赖 closed 标志(见 isAlive 注释),提前挂接关闭回调,
+        //保证握手期间对端断开也能立即感知。init() 在 accept 后重复注册为 vertx 替换语义,无副作用。
+        try {
+            this.endpoint
+                .closeHandler(ignore -> this.complete())
+                .disconnectHandler(ignore -> this.complete());
+        } catch (Throwable e) {
+            //endpoint 在构造时已被关闭:直接标记失活
+            this.closed = true;
+        }
     }
 
     private final Consumer<MqttConnection> defaultListener = mqttConnection -> {
@@ -145,11 +155,13 @@ class VertxMqttConnection implements MqttConnection {
             return this;
         }
         log.debug("mqtt client [{}] connected", getClientId());
-        accepted = true;
         try {
             if (!endpoint.isConnected()) {
                 endpoint.accept();
             }
+            //CONNACK 发出后再置位:保证 accepted=true 时 endpoint.isConnected() 必为 true,
+            //isAlive() 在 closed 标志与 isConnected 两种依据间切换时不存在瞬时失活窗口
+            accepted = true;
         } catch (Exception e) {
             close().subscribe();
             log.warn(e.getMessage(), e);
@@ -343,7 +355,12 @@ class VertxMqttConnection implements MqttConnection {
 
     @Override
     public boolean isAlive() {
-        return endpoint.isConnected() && (keepAliveTimeoutMs < 0 || ((System.currentTimeMillis() - lastPingTime) < keepAliveTimeoutMs));
+        //CONNACK(accept)之前 vertx MqttEndpoint.isConnected() 恒为 false,不能作为握手阶段的存活依据:
+        //会话注册发生在 accept 之前,注册过程中会话管理器会触发 getClientAddress -> takeConnection,
+        //若此阶段误报失活,新连接会被 takeConnection 当作死连接 disconnect,导致设备一上线即被断开。
+        //因此 accept 前以 closed 标志判活(构造器已提前挂接关闭回调),accept 后维持原语义。
+        return (accepted ? endpoint.isConnected() : !closed)
+            && (keepAliveTimeoutMs < 0 || ((System.currentTimeMillis() - lastPingTime) < keepAliveTimeoutMs));
     }
 
     @Override

--- a/jetlinks-components/network-component/mqtt-component/src/test/java/org/jetlinks/community/network/mqtt/gateway/device/session/MqttConnectionSessionTest.java
+++ b/jetlinks-components/network-component/mqtt-component/src/test/java/org/jetlinks/community/network/mqtt/gateway/device/session/MqttConnectionSessionTest.java
@@ -1,0 +1,367 @@
+package org.jetlinks.community.network.mqtt.gateway.device.session;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
+import org.jetlinks.community.gateway.monitor.DeviceGatewayMonitor;
+import org.jetlinks.community.gateway.monitor.GatewayMonitors;
+import org.jetlinks.community.network.mqtt.server.MqttConnection;
+import org.jetlinks.community.network.mqtt.server.MqttPublishing;
+import org.jetlinks.community.network.mqtt.server.MqttSubscription;
+import org.jetlinks.community.network.mqtt.server.MqttUnSubscription;
+import org.jetlinks.core.device.session.DeviceSessionEvent;
+import org.jetlinks.core.server.mqtt.MqttAuth;
+import org.jetlinks.core.device.session.DeviceSessionInfo;
+import org.jetlinks.core.device.session.DeviceSessionManager;
+import org.jetlinks.core.exception.DeviceOperationException;
+import org.jetlinks.core.message.codec.DefaultTransport;
+import org.jetlinks.core.message.codec.EncodedMessage;
+import org.jetlinks.core.message.codec.MqttMessage;
+import org.jetlinks.core.message.codec.SimpleMqttMessage;
+import org.jetlinks.core.server.session.DeviceSession;
+import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link MqttConnectionSession} 连接注册与下行发送回归测试.
+ * <p>
+ * 核心回归场景:连接注册发生在 CONNACK(accept)之前,此时 vertx 的 isConnected 恒为 false,
+ * 注册逻辑不得因 isAlive() 为 false 而静默丢弃连接,否则上行正常而全部下行报"设备连接已断开"。
+ */
+public class MqttConnectionSessionTest {
+
+    private final DeviceGatewayMonitor monitor = GatewayMonitors.getDeviceGatewayMonitor("unit-test");
+
+    private MqttConnectionSession newSession(MqttConnection connection) {
+        return new MqttConnectionSession(
+            "device-1", null, DefaultTransport.MQTT, connection, monitor, new FakeSessionManager());
+    }
+
+    private MqttMessage mqttMessage() {
+        return SimpleMqttMessage
+            .builder()
+            .topic("battery/v1/device-1/ack")
+            .payload(Unpooled.wrappedBuffer(new byte[]{1}))
+            .qosLevel(1)
+            .build();
+    }
+
+    /**
+     * 回归:CONNACK 前(isAlive=false)注册的连接必须入会话;accept 后下行必须可达.
+     */
+    @Test
+    public void registerBeforeConnackThenSendShouldWork() {
+        FakeMqttConnection connection = new FakeMqttConnection(false);
+        MqttConnectionSession session = newSession(connection);
+
+        //模拟网关在会话注册完成后才 accept(发送 CONNACK)
+        connection.accept();
+
+        StepVerifier.create(session.send(mqttMessage()))
+                    .expectNext(true)
+                    .verifyComplete();
+        assertEquals(1, connection.published.size());
+        assertTrue(session.isAlive());
+        assertEquals(1, session.getConnections().size());
+    }
+
+    /**
+     * 认证期间已断开的连接:注册后首个下行会将其清出会话并报连接断开(原守卫的兜底语义仍成立).
+     */
+    @Test
+    public void sendPurgesDeadConnectionAndFailsWhenEmpty() {
+        FakeMqttConnection connection = new FakeMqttConnection(false);
+        MqttConnectionSession session = newSession(connection);
+
+        StepVerifier.create(session.send(mqttMessage()))
+                    .expectErrorSatisfies(err -> assertInstanceOf(DeviceOperationException.class, err))
+                    .verify();
+        assertTrue(connection.disconnected);
+        assertTrue(session.getConnections().isEmpty());
+        assertFalse(session.isAlive());
+    }
+
+    /**
+     * 多连接会话:存在失活连接时下行仍应送达存活连接.
+     */
+    @Test
+    public void sendUsesAliveConnectionAmongMixed() {
+        FakeMqttConnection dead = new FakeMqttConnection(false);
+        FakeMqttConnection alive = new FakeMqttConnection(true);
+        MqttConnectionSession session = newSession(dead);
+        session.registerConnection(alive);
+
+        StepVerifier.create(session.send(mqttMessage()))
+                    .expectNext(true)
+                    .verifyComplete();
+        assertEquals(1, alive.published.size());
+        assertEquals(0, dead.published.size());
+    }
+
+    /**
+     * 会话关闭后注册连接:必须显式 reject(SERVER_UNAVAILABLE)而非静默接受.
+     */
+    @Test
+    public void registerAfterCloseRejectsServerUnavailable() {
+        FakeMqttConnection first = new FakeMqttConnection(true);
+        MqttConnectionSession session = newSession(first);
+        session.close();
+
+        FakeMqttConnection second = new FakeMqttConnection(true);
+        session.registerConnection(second);
+
+        assertEquals(MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE, second.rejectedCode);
+        assertFalse(session.getConnections().contains(second));
+    }
+
+    /**
+     * 正常存活连接注册(如 broker 形态注册已 accept 的连接)行为不变.
+     */
+    @Test
+    public void registerAliveConnectionStillWorks() {
+        FakeMqttConnection connection = new FakeMqttConnection(true);
+        MqttConnectionSession session = newSession(connection);
+
+        assertNull(connection.rejectedCode);
+        StepVerifier.create(session.send(mqttMessage()))
+                    .expectNext(true)
+                    .verifyComplete();
+        assertEquals(1, connection.published.size());
+    }
+
+    /**
+     * MQTT 连接测试替身:isAlive 可控,accept() 模拟 CONNACK 后 isConnected=true 的语义.
+     */
+    static class FakeMqttConnection implements MqttConnection {
+
+        volatile boolean alive;
+        volatile boolean disconnected;
+        volatile MqttConnectReturnCode rejectedCode;
+        final List<MqttMessage> published = new CopyOnWriteArrayList<>();
+        final List<Consumer<MqttConnection>> closeListeners = new CopyOnWriteArrayList<>();
+
+        FakeMqttConnection(boolean alive) {
+            this.alive = alive;
+        }
+
+        @Override
+        public String getClientId() {
+            return "device-1";
+        }
+
+        @Override
+        public Optional<MqttAuth> getAuth() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void reject(MqttConnectReturnCode code) {
+            this.rejectedCode = code;
+        }
+
+        @Override
+        public MqttConnection accept() {
+            this.alive = true;
+            return this;
+        }
+
+        @Override
+        public Optional<MqttMessage> getWillMessage() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Flux<MqttPublishing> handleMessage() {
+            return Flux.never();
+        }
+
+        @Override
+        public Mono<Void> publish(MqttMessage message) {
+            published.add(message);
+            return Mono.empty();
+        }
+
+        @Override
+        public Flux<MqttSubscription> handleSubscribe(boolean autoAck) {
+            return Flux.never();
+        }
+
+        @Override
+        public Flux<MqttUnSubscription> handleUnSubscribe(boolean autoAck) {
+            return Flux.never();
+        }
+
+        @Override
+        public void onClose(Consumer<MqttConnection> listener) {
+            closeListeners.add(listener);
+        }
+
+        @Override
+        public boolean isAlive() {
+            return alive;
+        }
+
+        @Override
+        public Mono<Void> close() {
+            return Mono.fromRunnable(this::doClose);
+        }
+
+        @Override
+        public long getLastPingTime() {
+            return System.currentTimeMillis();
+        }
+
+        @Override
+        public void keepAlive() {
+        }
+
+        @Override
+        public Duration getKeepAliveTimeout() {
+            return Duration.ofSeconds(60);
+        }
+
+        @Override
+        public void setKeepAliveTimeout(Duration duration) {
+        }
+
+        @Override
+        public InetSocketAddress getClientAddress() {
+            return InetSocketAddress.createUnresolved("127.0.0.1", 1883);
+        }
+
+        @Override
+        public InetSocketAddress address() {
+            return getClientAddress();
+        }
+
+        @Override
+        public Mono<Void> sendMessage(EncodedMessage message) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Flux<EncodedMessage> receiveMessage() {
+            return Flux.never();
+        }
+
+        @Override
+        public void disconnect() {
+            this.disconnected = true;
+            doClose();
+        }
+
+        private void doClose() {
+            this.alive = false;
+            for (Consumer<MqttConnection> listener : closeListeners) {
+                listener.accept(this);
+            }
+        }
+    }
+
+    /**
+     * 会话管理器测试替身:仅满足连接注销路径的 getSession 调用.
+     */
+    static class FakeSessionManager implements DeviceSessionManager {
+
+        @Override
+        public String getCurrentServerId() {
+            return "unit-test";
+        }
+
+        @Override
+        public Mono<DeviceSession> compute(String deviceId,
+                                           Function<Mono<DeviceSession>, Mono<DeviceSession>> computer) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<DeviceSession> compute(String deviceId,
+                                           Mono<DeviceSession> creator,
+                                           Function<DeviceSession, Mono<DeviceSession>> updater) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<DeviceSession> getSession(String deviceId) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<DeviceSession> getSession(String deviceId, boolean unregisterWhenNotAlive) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Flux<DeviceSession> getSessions() {
+            return Flux.empty();
+        }
+
+        @Override
+        public Mono<Long> remove(String deviceId, boolean onlyLocal) {
+            return Mono.just(0L);
+        }
+
+        @Override
+        public Mono<Long> remove(String deviceId, Predicate<DeviceSession> predicate) {
+            return Mono.just(0L);
+        }
+
+        @Override
+        public Mono<Boolean> isAlive(String deviceId, boolean onlyLocal) {
+            return Mono.just(false);
+        }
+
+        @Override
+        public Mono<Boolean> checkAlive(String deviceId, boolean onlyLocal) {
+            return Mono.just(false);
+        }
+
+        @Override
+        public Mono<Long> totalSessions(boolean onlyLocal) {
+            return Mono.just(0L);
+        }
+
+        @Override
+        public Flux<DeviceSessionInfo> getSessionInfo() {
+            return Flux.empty();
+        }
+
+        @Override
+        public Flux<DeviceSessionInfo> getDeviceSessionInfo(String deviceId) {
+            return Flux.empty();
+        }
+
+        @Override
+        public Flux<DeviceSessionInfo> getSessionInfo(String serverId) {
+            return Flux.empty();
+        }
+
+        @Override
+        public Flux<DeviceSessionInfo> getLocalSessionInfo() {
+            return Flux.empty();
+        }
+
+        @Override
+        public Disposable listenEvent(Function<DeviceSessionEvent, Mono<Void>> handler) {
+            return Disposables.disposed();
+        }
+    }
+}

--- a/jetlinks-components/network-component/mqtt-component/src/test/java/org/jetlinks/community/network/mqtt/server/vertx/VertxMqttConnectionTest.java
+++ b/jetlinks-components/network-component/mqtt-component/src/test/java/org/jetlinks/community/network/mqtt/server/vertx/VertxMqttConnectionTest.java
@@ -1,0 +1,149 @@
+package org.jetlinks.community.network.mqtt.server.vertx;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.mqtt.MqttEndpoint;
+import org.jetlinks.community.gateway.monitor.GatewayMonitors;
+import org.jetlinks.community.network.mqtt.gateway.device.session.MqttConnectionSession;
+import org.jetlinks.core.message.codec.DefaultTransport;
+import org.jetlinks.core.message.codec.SimpleMqttMessage;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import reactor.test.StepVerifier;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link VertxMqttConnection#isAlive()} 握手阶段存活语义回归测试.
+ * <p>
+ * 核心回归场景:vertx 的 {@code MqttEndpoint.isConnected()} 在 CONNACK(accept)之前恒为 false,
+ * 而会话注册发生在 accept 之前——注册过程中会话管理器(doRegister)会调用
+ * {@code session.getClientAddress()} 触发 takeConnection 的失活清理。
+ * 若 isAlive() 在握手阶段误报失活,新连接会被平台自己 disconnect,设备一上线即断开。
+ */
+public class VertxMqttConnectionTest {
+
+    /**
+     * 构造可控的 vertx endpoint 测试替身:
+     * isConnected 跟随 connected 标志,accept() 将其置位(模拟 CONNACK 同步生效),
+     * publish 立即回调成功.
+     */
+    private MqttEndpoint mockEndpoint(AtomicBoolean connected) {
+        MqttEndpoint endpoint = mock(MqttEndpoint.class, Mockito.RETURNS_SELF);
+        when(endpoint.keepAliveTimeSeconds()).thenReturn(60);
+        when(endpoint.clientIdentifier()).thenReturn("device-1");
+        when(endpoint.isConnected()).thenAnswer(inv -> connected.get());
+        when(endpoint.accept()).thenAnswer(inv -> {
+            connected.set(true);
+            return endpoint;
+        });
+        when(endpoint.remoteAddress()).thenReturn(SocketAddress.inetSocketAddress(51883, "127.0.0.1"));
+        when(endpoint.publish(Mockito.any(), Mockito.any(), Mockito.any(),
+                              Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyInt(),
+                              Mockito.any(), Mockito.any()))
+            .thenAnswer(inv -> {
+                inv.<Handler<AsyncResult<Integer>>>getArgument(7).handle(Future.succeededFuture(1));
+                return endpoint;
+            });
+        return endpoint;
+    }
+
+    /**
+     * 核心回归:CONNACK 前(isConnected=false)连接必须存活,否则握手期间会被误清理.
+     */
+    @Test
+    public void preAcceptConnectionMustBeAlive() {
+        VertxMqttConnection connection = new VertxMqttConnection(mockEndpoint(new AtomicBoolean(false)));
+
+        assertTrue(connection.isAlive());
+    }
+
+    /**
+     * 握手期间对端断开:构造器提前挂接的 closeHandler 必须使连接立即失活.
+     */
+    @Test
+    public void closeBeforeAcceptMarksDead() {
+        AtomicBoolean connected = new AtomicBoolean(false);
+        MqttEndpoint endpoint = mockEndpoint(connected);
+        VertxMqttConnection connection = new VertxMqttConnection(endpoint);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>> closeHandler = ArgumentCaptor.forClass(Handler.class);
+        verify(endpoint, atLeastOnce()).closeHandler(closeHandler.capture());
+        closeHandler.getValue().handle(null);
+
+        assertFalse(connection.isAlive());
+    }
+
+    /**
+     * accept 后语义与原实现一致:isAlive 跟随 endpoint.isConnected().
+     */
+    @Test
+    public void afterAcceptAliveFollowsEndpointConnected() {
+        AtomicBoolean connected = new AtomicBoolean(false);
+        VertxMqttConnection connection = new VertxMqttConnection(mockEndpoint(connected));
+
+        connection.accept();
+        assertTrue(connection.isAlive());
+
+        //连接断开(未触发 closeHandler 的瞬间)也必须立即失活
+        connected.set(false);
+        assertFalse(connection.isAlive());
+    }
+
+    /**
+     * 被拒绝的连接必须失活.
+     */
+    @Test
+    public void rejectMarksDead() {
+        VertxMqttConnection connection = new VertxMqttConnection(mockEndpoint(new AtomicBoolean(false)));
+
+        connection.reject(MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE);
+
+        assertFalse(connection.isAlive());
+    }
+
+    /**
+     * 端到端复现生产杀链:注册(CONNACK 前) -> 会话管理器 doRegister 读取 getClientAddress
+     * (内部触发 takeConnection 失活清理) -> accept -> 下行发送.
+     * 全程连接不得被清出会话,下行必须可达.
+     */
+    @Test
+    public void registrationAddressLookupMustNotKillHandshakingConnection() {
+        AtomicBoolean connected = new AtomicBoolean(false);
+        VertxMqttConnection connection = new VertxMqttConnection(mockEndpoint(connected));
+        MqttConnectionSession session = new MqttConnectionSession(
+            "device-1", null, DefaultTransport.MQTT, connection,
+            GatewayMonitors.getDeviceGatewayMonitor("unit-test"), null);
+
+        //doRegister: session.getClientAddress().map(InetSocketAddress::toString)...
+        assertTrue(session.getClientAddress().isPresent());
+        //连接必须仍在会话中且存活(修复前:此处已被 disconnect 并清出会话)
+        assertTrue(connection.isAlive());
+        assertTrue(session.isAlive());
+        assertFalse(session.getConnections().isEmpty());
+
+        connection.accept();
+
+        StepVerifier.create(session.send(SimpleMqttMessage
+                                             .builder()
+                                             .topic("battery/v1/device-1/ack")
+                                             .payload(Unpooled.wrappedBuffer(new byte[]{1}))
+                                             .qosLevel(1)
+                                             .build()))
+                    .expectNext(true)
+                    .verifyComplete();
+    }
+}


### PR DESCRIPTION
## 问题现象

MQTT 直连网关接入的设备:上行消息一切正常,但所有平台下行(协议包回 ACK、指令下发)全部失败,报 `DeviceOperationException: connection_lost(设备连接已断开)`。

可用 MQTTX 稳定复现:认证通过、正常发布消息,任何需要平台下行的操作必现。

## 根因

vertx 的 `MqttEndpointImpl.isConnected` 只在发出 CONNACK 时才置位(`connack()` 内同步赋值),而会话注册发生在 CONNACK 之前(`DeviceMqttConnection.handleAuth` 中 `sessionManager.compute(...)` 先于 `connection.accept()`),因此 `VertxMqttConnection.isAlive()` 在整个握手期恒为 false,引发两条故障链:

1. `MqttConnectionSession.registerConnection` 中的 `!connection.isAlive()` 守卫把每个新连接静默丢弃 → 会话连接列表恒空 → `send()` 时 `takeConnection()` 返回 null → 所有下行 `connection_lost`(上行不经会话连接列表,所以正常,问题极具迷惑性);
2. 若仅移除该守卫,会话管理器注册流程(`doRegister` → `session.getClientAddress()` → `takeConnection()`)会把握手中的连接判为失活并 `disconnect()` → 设备一上线即被平台自己断开。

## 修复

统一契约:isAlive 在连接全生命周期都必须真实。

- `VertxMqttConnection.isAlive()`:accept 前以 `closed` 标志判活,accept 后维持原语义(`endpoint.isConnected()` + 心跳窗口,逐字节不变);
- `accept()`:`accepted` 在 CONNACK 发出后置位,保证 `accepted ⟹ isConnected` 恒成立,两种判活依据切换无瞬时窗口;
- 构造器提前注册 close/disconnect 回调(vertx 在处理 CONNECT 时已接通 socket closeHandler,CONNACK 前注册合法),握手期对端断开可立即感知;
- `registerConnection` 移除 isAlive 准入守卫,失活连接由 takeConnection/onClose 兜底清理。

## 测试

新增 `MqttConnectionSessionTest` + `VertxMqttConnectionTest` 共 10 个用例,其中包含用真实 `VertxMqttConnection` 端到端复现注册期杀链(注册 → doRegister 读地址 → accept → 下行);去掉修复代码后这些用例即红,可作为该缺陷的回归防线。

已在 2.12 最新代码基线上编译并全部通过。
