### PR TITLE
fix(ci): 关闭 ACR 不兼容的构建证明

### DIFF
--- a/.github/workflows/maven_build_2.1x.yml
+++ b/.github/workflows/maven_build_2.1x.yml
@@ -41,5 +41,7 @@ jobs:
                     file: ./jetlinks-standalone/Dockerfile
                     platforms: linux/amd64,linux/arm64/v8
                     push: true
+                    # ACR 当前不兼容 BuildKit provenance attestation 的 OCI manifest。
+                    provenance: false
                     tags: |
                         registry.cn-shenzhen.aliyuncs.com/jetlinks/jetlinks-community:${{ steps.maven-version.outputs.version }}


### PR DESCRIPTION
## 目的

- 修复 `Auto Deploy Docker` 在阿里云 ACR 推送多架构镜像时失败的问题
- 保留 `linux/amd64` 与 `linux/arm64/v8` 镜像发布能力

## 核心变动

- `.github/workflows/maven_build_2.1x.yml`：关闭 `docker/build-push-action` 自动生成的 provenance attestation
- 保留现有多架构构建、镜像标签和 ACR 推送配置
- 阶段提交：`37e47ed78 fix(ci): 关闭 ACR 不兼容的构建证明`
- 目标基准分支：`2.12`

## 设计与测试目标

- 任务契约：不适用，本次为单文件 CI 配置兼容性修复
- 权威文档：不适用，未改变仓库长期使用方式
- 用户确认：已确认
- 测试目标：workflow YAML 可解析，GitHub Actions 表达式和 action 配置有效，Docker 多架构发布不再附带 ACR 当前无法识别的 provenance manifest
- 注释 / 公共契约：不适用；已在 workflow 配置旁说明 ACR 兼容性原因
- 数据权限：不适用
- 数据库兼容与性能：不适用
- 链路追踪：不适用
- MBean 运维可观测性：不适用
- 系统性求解：适用；共同根因是托管 runner 自动升级到 Buildx `v0.36.1` / BuildKit `v0.32.2` 后生成的 attestation 被 ACR 拒绝；已用相邻失败 run 和此前成功 run 验证该变化轴

## 测试结果

- 测试命令：`ruby -e 'require "yaml"; YAML.load_file(".github/workflows/maven_build_2.1x.yml")'`
- 结果：1 个 workflow YAML 解析通过
- 测试命令：`actionlint -ignore 'actions/cache@v3' -ignore 'SC2086' .github/workflows/maven_build_2.1x.yml`
- 结果：1 个 workflow 定向检查通过；完整检查仍有 2 个既有诊断（`actions/cache@v3`、`SC2086`），与本次改动无关
- 证据来源与复用判断：失败 run [32326614823](https://github.com/jetlinks/jetlinks-community/actions/runs/32326614823) 在 Buildx `v0.36.1` / BuildKit `v0.32.2` 下于 manifest 推送阶段报 `unknown manifest class for application/vnd.oci.empty.v1+json`；相邻 run [32321969057](https://github.com/jetlinks/jetlinks-community/actions/runs/32321969057) 同样失败；成功 run [31561748038](https://github.com/jetlinks/jetlinks-community/actions/runs/31561748038) 使用 Buildx `v0.35.0` / BuildKit `v0.31.2`
- 新增/更新测试：无，本次仅修改 CI 配置
- 单元测试：0 executed；不适用，本次未修改 Java 代码
- 集成测试：待 PR CI 执行；需要真实 GitHub runner、BuildKit 和 ACR，无法在本地等价验证远端 manifest 接受行为
- 压力测试：不适用
- 覆盖率：不适用；本次未修改 Java 源代码

## 文档同步情况

- 已同步：无
- 未同步：无
- 说明：本次为 CI 构建兼容性修复，不涉及长期文档契约

## 风险与说明

- 影响范围：`2.10`、`2.11`、`2.12` 分支共用的 Docker 发布 workflow
- 兼容性与发布边界：不涉及应用运行时和已发布业务兼容性
- 注释 / 公共契约：不涉及
- 数据库兼容与 SQL 性能：不涉及
- 链路追踪 / 可观测性：不涉及
- MBean / 运维可观测性：不涉及
- 未覆盖场景：PR 合并前尚未在真实 ACR 上完成修复后的再次推送
- 已知限制：关闭 provenance 后镜像不再携带 BuildKit 构建证明；若后续要求供应链证明，应升级 ACR 能力或迁移到支持 OCI attestation 的镜像仓库
- 回滚方式：删除 `provenance: false` 配置或回滚提交 `37e47ed78`
