### PR TITLE
test(设备网关): 补充TCP上行监控回归测试

### DIFF
--- a/jetlinks-components/network-component/tcp-component/src/test/java/org/jetlinks/community/network/tcp/gateway/device/TcpServerDeviceGatewayMonitorTest.java
+++ b/jetlinks-components/network-component/tcp-component/src/test/java/org/jetlinks/community/network/tcp/gateway/device/TcpServerDeviceGatewayMonitorTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.community.network.tcp.gateway.device;
+
+import io.netty.buffer.Unpooled;
+import org.jetlinks.community.gateway.monitor.DeviceGatewayMonitor;
+import org.jetlinks.community.gateway.monitor.GatewayMonitors;
+import org.jetlinks.community.network.tcp.TcpMessage;
+import org.jetlinks.community.network.tcp.client.TcpClient;
+import org.jetlinks.community.network.tcp.server.TcpServer;
+import org.jetlinks.core.ProtocolSupport;
+import org.jetlinks.core.device.DeviceInfo;
+import org.jetlinks.core.device.DeviceRegistry;
+import org.jetlinks.core.device.ProductInfo;
+import org.jetlinks.core.device.session.DeviceSessionManager;
+import org.jetlinks.core.message.DeviceMessage;
+import org.jetlinks.core.message.codec.DeviceMessageCodec;
+import org.jetlinks.core.message.codec.EncodedMessage;
+import org.jetlinks.core.message.codec.FromDeviceMessageContext;
+import org.jetlinks.core.message.codec.Transport;
+import org.jetlinks.core.message.property.ReportPropertyMessage;
+import org.jetlinks.core.server.ClientConnection;
+import org.jetlinks.core.server.session.DeviceSession;
+import org.jetlinks.supports.device.session.LocalDeviceSessionManager;
+import org.jetlinks.supports.server.DecodedClientMessageHandler;
+import org.jetlinks.supports.test.InMemoryDeviceRegistry;
+import org.jetlinks.supports.test.MockProtocolSupport;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+import javax.annotation.Nonnull;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TcpServerDeviceGatewayMonitorTest {
+
+    @Test
+    void manualAndReturnedTcpUpstreamShouldUseMonitorChainOnce() throws InterruptedException {
+        String gatewayId = "tcp-monitor-test";
+        RecordingMonitor monitor = new RecordingMonitor();
+        GatewayMonitors.register((id, tags) -> gatewayId.equals(id) ? monitor : null);
+
+        DeviceMessageCodec codec = mock(DeviceMessageCodec.class);
+        ProtocolSupport protocol = new MockProtocolSupport() {
+            @Nonnull
+            @Override
+            public Mono<DeviceMessageCodec> getMessageCodec(Transport transport) {
+                return Mono.just(codec);
+            }
+        };
+        DeviceRegistry registry = new InMemoryDeviceRegistry();
+        String productId = "monitor-test-product";
+        Mono<Void> registerDevices = registry
+            .register(ProductInfo.builder().id(productId).protocol("test").build())
+            .then(registry.register(DeviceInfo
+                                        .builder()
+                                        .id("manual-device")
+                                        .productId(productId)
+                                        .build()))
+            .then(registry.register(DeviceInfo
+                                        .builder()
+                                        .id("returned-device")
+                                        .productId(productId)
+                                        .build()))
+            .then();
+        StepVerifier.create(registerDevices).verifyComplete();
+        DeviceSessionManager sessionManager = LocalDeviceSessionManager.create();
+        DecodedClientMessageHandler messageHandler = (deviceOperator, message) -> Mono.just(true);
+        TcpServer server = mock(TcpServer.class);
+        TcpClient client = mock(TcpClient.class);
+        ReportPropertyMessage manualMessage = new ReportPropertyMessage();
+        manualMessage.setDeviceId("manual-device");
+        ReportPropertyMessage returnedMessage = new ReportPropertyMessage();
+        returnedMessage.setDeviceId("returned-device");
+        TcpMessage origin = new TcpMessage(Unpooled.EMPTY_BUFFER);
+        Sinks.Many<TcpClient> clients = Sinks.many().unicast().onBackpressureBuffer();
+        Sinks.Many<TcpMessage> messages = Sinks.many().replay().all();
+
+        when(codec.decode(any())).thenAnswer(invocation -> {
+            FromDeviceMessageContext context = invocation.getArgument(0);
+            return context
+                .handleMessage(manualMessage)
+                .thenMany(Flux.just(returnedMessage));
+        });
+        when(server.handleConnection()).thenReturn(clients.asFlux());
+        when(client.subscribe()).thenReturn(messages.asFlux());
+        when(client.getRemoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 1883));
+        when(client.getId()).thenReturn("tcp-client");
+
+        TcpServerDeviceGateway gateway = new TcpServerDeviceGateway(
+            gatewayId,
+            Mono.just(protocol),
+            registry,
+            messageHandler,
+            sessionManager,
+            server
+        );
+        StepVerifier.create(gateway.startup()).verifyComplete();
+
+        assertEquals(Sinks.EmitResult.OK, clients.tryEmitNext(client));
+        assertEquals(Sinks.EmitResult.OK, messages.tryEmitNext(origin));
+        assertTrue(monitor.completed.await(Duration.ofSeconds(5).toMillis(), TimeUnit.MILLISECONDS));
+
+        assertEquals(1, monitor.beforeDecode.get());
+        assertEquals(1, monitor.decode.get());
+        assertEquals(2, monitor.beforeSend.get());
+        assertEquals(2, monitor.received.get());
+        assertEquals(1, Collections.frequency(monitor.monitored, manualMessage));
+        assertEquals(1, Collections.frequency(monitor.monitored, returnedMessage));
+        assertSame(origin, monitor.origin);
+
+        messages.tryEmitComplete();
+        clients.tryEmitComplete();
+        StepVerifier.create(gateway.shutdown()).verifyComplete();
+    }
+
+    private static class RecordingMonitor implements DeviceGatewayMonitor {
+        private final AtomicInteger beforeDecode = new AtomicInteger();
+        private final AtomicInteger decode = new AtomicInteger();
+        private final AtomicInteger beforeSend = new AtomicInteger();
+        private final AtomicInteger received = new AtomicInteger();
+        private final CountDownLatch completed = new CountDownLatch(2);
+        private final List<DeviceMessage> monitored = new CopyOnWriteArrayList<>();
+        private EncodedMessage origin;
+
+        @Override
+        public void receivedMessage() {
+            received.incrementAndGet();
+        }
+
+        @Override
+        public boolean beforeDecode(ClientConnection connection, EncodedMessage message) {
+            beforeDecode.incrementAndGet();
+            origin = message;
+            return true;
+        }
+
+        @Override
+        public Flux<DeviceMessage> decode(ClientConnection connection,
+                                          DeviceSession session,
+                                          EncodedMessage origin,
+                                          Flux<DeviceMessage> decoder) {
+            decode.incrementAndGet();
+            return decoder;
+        }
+
+        @Override
+        public Flux<DeviceMessage> beforeSendToPlatform(ClientConnection connection,
+                                                        DeviceSession session,
+                                                        EncodedMessage origin,
+                                                        Flux<DeviceMessage> handler) {
+            beforeSend.incrementAndGet();
+            return handler.doOnNext(message -> {
+                monitored.add(message);
+                completed.countDown();
+            });
+        }
+    }
+}


### PR DESCRIPTION
## 目的

- 补充社区版 TCP 设备网关上行监控集成回归测试。
- 防止协议手动上报与 codec 返回消息在 monitor 接入后被重复提交平台。

## 核心变动

- 模块 / 文件：`tcp-component` 新增 `TcpServerDeviceGatewayMonitorTest`。
- 行为变化：不修改生产行为；新增真实网关启动、连接订阅和设备注册测试。
- 边界或约束变化：同一 TCP 原始报文分别产生手动上报消息和 codec 返回消息，断言两条消息各进入平台与 monitor 一次。
- 阶段提交：`58ce9fcae test(设备网关): 补充TCP上行监控回归测试`

## 设计与测试目标

- 任务契约：不适用；本次为单一既有行为回归测试补强，不新增后端契约。
- 权威文档：不适用；生产行为和长期协议契约未变化。
- 用户确认：已确认补充社区版测试并提交 PR。
- 测试目标：覆盖 TCP 原始报文、`context.handleMessage(...)` 手动上报、codec 返回消息、平台处理及 monitor 包装完整路径；断言每条消息只处理一次。
- 注释 / 公共契约：不适用；未修改生产类、SPI 或公共契约，测试文件已包含项目许可证头。
- 数据权限：不适用；不涉及 CRUD 或 AssetsHolder。
- 数据库兼容与性能：不适用；不涉及数据库或 SQL。
- 链路追踪：不适用；仅新增测试，生产链路已有 `FluxTracer`。
- MBean 运维可观测性：不适用；不涉及常驻任务、缓存、队列或执行器。
- 系统性求解：不适用；生产实现未变，回归不变量已由手动消息与返回消息两个代表来源直接验证。

## 测试结果

- 测试命令：`JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -o -pl jetlinks-components/network-component/tcp-component -am -Dtest=TcpServerDeviceGatewayMonitorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- 证据来源与复用判断：本地 JDK 17 最终候选 tree `8afa4e3fcf52aae04e93ac4506a4251e5b66c97b` 定向补跑；提交后 Git tree 未变化，可直接复用。
- 新增/更新测试：`TcpServerDeviceGatewayMonitorTest#manualAndReturnedTcpUpstreamShouldUseMonitorChainOnce`。
- 单元测试：Surefire 共 1 个测试，通过 1，失败 0，错误 0，跳过 0；关联 Reactor 10 个模块均构建成功。
- 集成测试结果或不适用原因：进程内 TCP 网关集成场景通过；覆盖网关启动、连接订阅、协议解码、设备注册和平台消息处理，不依赖外部 TCP 服务。
- 压力测试结果或不适用原因：不适用；仅增加单报文链路回归测试，不修改性能路径。
- 覆盖率：JaCoCo 0.8.7；`handleTcpMessage0` 行覆盖 17/19（89.5%）、分支覆盖 3/6（50%）；`TcpConnection` 行覆盖 91/134（67.9%）。

## 文档同步情况

- 已同步：无。
- 未同步：无。
- 说明：生产行为和权威契约未变化；测试证据保留在 PR 与 CI 中。

## 风险与说明

- 影响范围：仅社区版 `tcp-component` 测试源码。
- 兼容性与发布边界：不涉及已发布兼容性；无生产代码变化。
- 注释 / 公共契约：不涉及；未修改公共类或 SPI。
- 数据库兼容与 SQL 性能：不涉及。
- 链路追踪 / 可观测性：生产链路已有追踪，本次不修改。
- MBean / 运维可观测性：不涉及。
- 未覆盖场景：未启动真实 TCP Socket；本测试聚焦设备网关收到报文后的上行处理与 monitor 调用次数。
- 已知限制：协议若手动处理后又返回同一条消息，仍违反 `FromDeviceMessageContext` 的空流契约，本测试不把该错误用法视为网关自动去重责任。
- 回滚方式：回滚提交 `58ce9fcae` 即可，仅删除新增测试。
