### PR TITLE
fix(设备网关): 补齐上行监控包装器委托

### DIFF
--- a/jetlinks-components/gateway-component/src/main/java/org/jetlinks/community/gateway/monitor/CompositeDeviceGatewayMonitor.java
+++ b/jetlinks-components/gateway-component/src/main/java/org/jetlinks/community/gateway/monitor/CompositeDeviceGatewayMonitor.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 class CompositeDeviceGatewayMonitor implements DeviceGatewayMonitor {
 
@@ -119,6 +120,21 @@ class CompositeDeviceGatewayMonitor implements DeviceGatewayMonitor {
             decoder = monitor.decode(connection, session, origin, decoder);
         }
         return decoder;
+    }
+
+    @Override
+    public Flux<DeviceMessage> handleUpstream(@Nullable ClientConnection connection,
+                                              DeviceSession session,
+                                              EncodedMessage origin,
+                                              Flux<DeviceMessage> decoder,
+                                              UnaryOperator<Flux<DeviceMessage>> platformHandler) {
+        // 平台处理器作为链尾只组合一次，同时保留 beforeSendToPlatform 的注册顺序。
+        UnaryOperator<Flux<DeviceMessage>> handler = platformHandler;
+        for (DeviceGatewayMonitor monitor : monitors) {
+            UnaryOperator<Flux<DeviceMessage>> next = handler;
+            handler = source -> monitor.handleUpstream(connection, session, origin, source, next);
+        }
+        return handler.apply(decoder);
     }
 
     @Override

--- a/jetlinks-components/gateway-component/src/main/java/org/jetlinks/community/gateway/monitor/LazyDeviceGatewayMonitor.java
+++ b/jetlinks-components/gateway-component/src/main/java/org/jetlinks/community/gateway/monitor/LazyDeviceGatewayMonitor.java
@@ -24,6 +24,7 @@ import reactor.core.publisher.Mono;
 
 import javax.annotation.Nullable;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 class LazyDeviceGatewayMonitor implements DeviceGatewayMonitor {
 
@@ -99,6 +100,15 @@ class LazyDeviceGatewayMonitor implements DeviceGatewayMonitor {
                                       EncodedMessage origin,
                                       Flux<DeviceMessage> decoder) {
         return getTarget().decode(connection, session, origin, decoder);
+    }
+
+    @Override
+    public Flux<DeviceMessage> handleUpstream(@Nullable ClientConnection connection,
+                                              DeviceSession session,
+                                              EncodedMessage origin,
+                                              Flux<DeviceMessage> decoder,
+                                              UnaryOperator<Flux<DeviceMessage>> platformHandler) {
+        return getTarget().handleUpstream(connection, session, origin, decoder, platformHandler);
     }
 
     @Override

--- a/jetlinks-components/gateway-component/src/test/java/org/jetlinks/community/gateway/monitor/DeviceGatewayMonitorTest.java
+++ b/jetlinks-components/gateway-component/src/test/java/org/jetlinks/community/gateway/monitor/DeviceGatewayMonitorTest.java
@@ -241,6 +241,107 @@ class DeviceGatewayMonitorTest {
     }
 
     @Test
+    void shouldDelegateCompositeHandleUpstreamWithoutDuplicatingPlatformHandler() {
+        List<String> signals = new ArrayList<>();
+        AtomicInteger platformApplied = new AtomicInteger();
+        AtomicInteger platformHandled = new AtomicInteger();
+        HandleUpstreamRecordingMonitor first = new HandleUpstreamRecordingMonitor("first", signals);
+        HandleUpstreamRecordingMonitor second = new HandleUpstreamRecordingMonitor("second", signals);
+        CompositeDeviceGatewayMonitor monitor = new CompositeDeviceGatewayMonitor()
+            .add(first, second);
+
+        ClientConnection connection = mock(ClientConnection.class);
+        DeviceSession session = mock(DeviceSession.class);
+        EncodedMessage origin = mock(EncodedMessage.class);
+        DeviceMessage message = mock(DeviceMessage.class);
+
+        Flux<DeviceMessage> upstream = monitor.handleUpstream(
+            connection,
+            session,
+            origin,
+            Flux.just(message),
+            decoder -> {
+                platformApplied.incrementAndGet();
+                return decoder.doOnNext(ignore -> {
+                    platformHandled.incrementAndGet();
+                    signals.add("platform");
+                });
+            }
+        );
+
+        assertEquals(1, platformApplied.get());
+        StepVerifier
+            .create(upstream)
+            .expectNext(message)
+            .verifyComplete();
+
+        assertEquals(1, first.handleUpstreamInvocations.get());
+        assertEquals(1, second.handleUpstreamInvocations.get());
+        assertEquals(1, platformHandled.get());
+        assertEquals(Arrays.asList("platform", "first", "second"), signals);
+    }
+
+    @Test
+    void shouldApplyPlatformHandlerOnceForEmptyComposite() {
+        AtomicInteger platformApplied = new AtomicInteger();
+        AtomicInteger platformHandled = new AtomicInteger();
+        DeviceMessage message = mock(DeviceMessage.class);
+
+        Flux<DeviceMessage> upstream = new CompositeDeviceGatewayMonitor()
+            .handleUpstream(
+                mock(ClientConnection.class),
+                mock(DeviceSession.class),
+                mock(EncodedMessage.class),
+                Flux.just(message),
+                decoder -> {
+                    platformApplied.incrementAndGet();
+                    return decoder.doOnNext(ignore -> platformHandled.incrementAndGet());
+                }
+            );
+
+        assertEquals(1, platformApplied.get());
+        StepVerifier
+            .create(upstream)
+            .expectNext(message)
+            .verifyComplete();
+        assertEquals(1, platformHandled.get());
+    }
+
+    @Test
+    void shouldDelegateLazyHandleUpstreamToTarget() {
+        List<String> signals = new ArrayList<>();
+        AtomicInteger resolved = new AtomicInteger();
+        AtomicInteger platformHandled = new AtomicInteger();
+        HandleUpstreamRecordingMonitor target = new HandleUpstreamRecordingMonitor("target", signals);
+        LazyDeviceGatewayMonitor monitor = new LazyDeviceGatewayMonitor(() -> {
+            resolved.incrementAndGet();
+            return target;
+        });
+        DeviceMessage message = mock(DeviceMessage.class);
+
+        Flux<DeviceMessage> upstream = monitor.handleUpstream(
+            mock(ClientConnection.class),
+            mock(DeviceSession.class),
+            mock(EncodedMessage.class),
+            Flux.just(message),
+            decoder -> decoder.doOnNext(ignore -> {
+                platformHandled.incrementAndGet();
+                signals.add("platform");
+            })
+        );
+
+        StepVerifier
+            .create(upstream)
+            .expectNext(message)
+            .verifyComplete();
+
+        assertEquals(1, resolved.get());
+        assertEquals(1, target.handleUpstreamInvocations.get());
+        assertEquals(1, platformHandled.get());
+        assertEquals(Arrays.asList("platform", "target"), signals);
+    }
+
+    @Test
     void shouldComposeAllMonitorDecisionsAndReactiveWrappersInOrder() {
         List<String> signals = new ArrayList<>();
         RecordingMonitor first = new RecordingMonitor("first", true, true, signals);
@@ -418,6 +519,37 @@ class DeviceGatewayMonitorTest {
                                      EncodedMessage origin,
                                      Mono<Void> sender) {
             return sender.doOnSuccess(ignore -> signals.add(id + ":downstream"));
+        }
+    }
+
+    private static class HandleUpstreamRecordingMonitor implements DeviceGatewayMonitor {
+
+        private final String id;
+        private final List<String> signals;
+        private final AtomicInteger handleUpstreamInvocations = new AtomicInteger();
+
+        private HandleUpstreamRecordingMonitor(String id, List<String> signals) {
+            this.id = id;
+            this.signals = signals;
+        }
+
+        @Override
+        public Flux<DeviceMessage> handleUpstream(ClientConnection connection,
+                                                  DeviceSession session,
+                                                  EncodedMessage origin,
+                                                  Flux<DeviceMessage> decoder,
+                                                  UnaryOperator<Flux<DeviceMessage>> platformHandler) {
+            handleUpstreamInvocations.incrementAndGet();
+            return DeviceGatewayMonitor.super
+                .handleUpstream(connection, session, origin, decoder, platformHandler);
+        }
+
+        @Override
+        public Flux<DeviceMessage> beforeSendToPlatform(ClientConnection connection,
+                                                        DeviceSession session,
+                                                        EncodedMessage origin,
+                                                        Flux<DeviceMessage> handler) {
+            return handler.doOnNext(ignore -> signals.add(id));
         }
     }
 }

--- a/jetlinks-components/network-component/tcp-component/src/test/java/org/jetlinks/community/network/tcp/gateway/device/TcpServerDeviceGatewayMonitorTest.java
+++ b/jetlinks-components/network-component/tcp-component/src/test/java/org/jetlinks/community/network/tcp/gateway/device/TcpServerDeviceGatewayMonitorTest.java
@@ -53,6 +53,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.UnaryOperator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -132,6 +133,7 @@ class TcpServerDeviceGatewayMonitorTest {
 
         assertEquals(1, monitor.beforeDecode.get());
         assertEquals(1, monitor.decode.get());
+        assertEquals(2, monitor.handleUpstream.get());
         assertEquals(2, monitor.beforeSend.get());
         assertEquals(2, monitor.received.get());
         assertEquals(1, Collections.frequency(monitor.monitored, manualMessage));
@@ -146,6 +148,7 @@ class TcpServerDeviceGatewayMonitorTest {
     private static class RecordingMonitor implements DeviceGatewayMonitor {
         private final AtomicInteger beforeDecode = new AtomicInteger();
         private final AtomicInteger decode = new AtomicInteger();
+        private final AtomicInteger handleUpstream = new AtomicInteger();
         private final AtomicInteger beforeSend = new AtomicInteger();
         private final AtomicInteger received = new AtomicInteger();
         private final CountDownLatch completed = new CountDownLatch(2);
@@ -171,6 +174,17 @@ class TcpServerDeviceGatewayMonitorTest {
                                           Flux<DeviceMessage> decoder) {
             decode.incrementAndGet();
             return decoder;
+        }
+
+        @Override
+        public Flux<DeviceMessage> handleUpstream(ClientConnection connection,
+                                                  DeviceSession session,
+                                                  EncodedMessage origin,
+                                                  Flux<DeviceMessage> decoder,
+                                                  UnaryOperator<Flux<DeviceMessage>> platformHandler) {
+            handleUpstream.incrementAndGet();
+            return DeviceGatewayMonitor.super
+                .handleUpstream(connection, session, origin, decoder, platformHandler);
         }
 
         @Override


### PR DESCRIPTION
## 目的

- 修复 `CompositeDeviceGatewayMonitor` 和 `LazyDeviceGatewayMonitor` 未完整委托 `handleUpstream`，导致自定义上行监控逻辑被绕过的问题。
- 保证协议手动上报与 codec 返回消息均进入现有监控链，同时避免平台处理和消息上报重复执行。

## 核心变动

- 模块 / 文件：`gateway-component` 的 Composite/Lazy monitor，以及对应单元测试和 TCP 集成回归测试。
- 行为变化：Composite 以中间件链方式组合子 monitor 的 `handleUpstream`；Lazy 直接委托真实 target。
- 边界或约束变化：`platformHandler` 仅在链尾组合一次；保留 `beforeSendToPlatform` 注册顺序；空 Composite 仍正常执行平台处理。
- 阶段提交：`e485401e21fa0e9a03a7536e08ec055b1ad97cb9`。

## 设计与测试目标

- 任务契约：当前 Codex 任务上下文；目标、非目标和验收信号已由用户逐项确认，未写入仓库权威文档。
- 权威文档：不适用；现有 `DeviceGatewayMonitor` SPI 契约和 `2.12` 语义未变化。
- 用户确认：已确认，用户明确要求提交 PR。
- 测试目标：覆盖自定义 Composite/Lazy 委托、平台处理一次、单消息一次、空 Composite 边界，以及 TCP 手动上报和 codec 返回消息回归。
- 注释 / 公共契约：适用；SPI 方法已有完整契约、`@since 2.12` 和关联类型说明，Composite 的非显式链式顺序已补代码注释。
- 数据权限：不适用；不涉及 CRUD 或 AssetsHolder。
- 数据库兼容与性能：不适用；不涉及数据库、SQL 或性能敏感算法。
- 链路追踪：不适用；本次仅修复已有 Reactor 监控包装器委托，不新增业务阶段、外部 I/O 或上下文边界。
- MBean 运维可观测性：不适用；不新增常驻任务、缓存、队列或资源管理器。
- 系统性求解：适用；违反的不变量是包装器必须完整委托 SPI 且平台处理只能执行一次。共同根因为 Composite/Lazy 未覆盖 `handleUpstream`；修复未增加场景特调。已验证 Composite 原场景、Lazy 同类场景、空 Composite 边界及 TCP 回归。

## 测试结果

- 测试命令：`cd jetlinks-components/gateway-component && mvn -Dtest=DeviceGatewayMonitorTest test`；`mvn -pl jetlinks-components/network-component/tcp-component -am -Dtest=TcpServerDeviceGatewayMonitorTest -Dsurefire.failIfNoSpecifiedTests=false test`。
- 证据来源与复用判断：本地阶段验证；被测 tree `4bef75ac47b44e32a1f39756f9d4766bb8e6dd21`，提交后源码、测试、依赖和 `origin/2.12` 均未变化，复用有效。
- 新增/更新测试：`DeviceGatewayMonitorTest` 新增 Composite、空 Composite、Lazy 用例；`TcpServerDeviceGatewayMonitorTest` 增加自定义 `handleUpstream` 调用次数断言。
- 单元测试：`DeviceGatewayMonitorTest` 9 个通过，0 失败，0 错误，0 跳过。
- 集成测试结果或不适用原因：TCP 上行集成回归 1 个通过，0 失败，0 错误，0 跳过；手动消息和 codec 返回消息各监控一次，`handleUpstream` 共调用 2 次。
- 压力测试结果或不适用原因：不适用；改动为固定数量 monitor 的函数链组合，不改变消息并发、缓存或 I/O 模型。
- 覆盖率：JaCoCo 中 Composite `handleUpstream` 行 6/6、分支 2/2；Lazy `handleUpstream` 行 1/1。

## 文档同步情况

- 已同步：不适用。
- 未同步：无。
- 说明：公共 SPI 契约未变化；测试证据保留在 PR / CI，不新增任务流水文档。

## 风险与说明

- 影响范围：设备网关上行监控包装器及 TCP 上行回归，不修改网络协议或消息模型。
- 兼容性与发布边界：不新增或删除公共方法，保留 `beforeSendToPlatform` 既有顺序语义。
- 注释 / 公共契约：复用现有 SPI 契约，并为 Composite 的链式组合补充原因注释。
- 数据库兼容与 SQL 性能：不涉及。
- 链路追踪 / 可观测性：不新增埋点；继续使用现有 monitor 与 Reactor Context 传播。
- MBean / 运维可观测性：不涉及。
- 未覆盖场景：未逐一启动所有网络传输组件；公共包装器单测和 TCP 真实上行链路已覆盖共同契约。
- 已知限制：自定义 monitor 实现仍需遵守 SPI，不主动订阅并正确组合传入的 `platformHandler`。
- 回滚方式：回滚提交 `e485401e21fa0e9a03a7536e08ec055b1ad97cb9`。
